### PR TITLE
Build on stable.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,4 @@
-# TODO [Issue #654]: unpin version when issue will be resolved.
 [toolchain]
-channel = "nightly-2023-02-21"
+channel = "stable"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
substrate recently stopped requiring nightly to build the runtime