### PR TITLE
Remove unnecessary `self::` in all pallets

### DIFF
--- a/pallets/pallet-proxy/src/lib.rs
+++ b/pallets/pallet-proxy/src/lib.rs
@@ -93,7 +93,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			// already same valid proxy account.
-			let account_exit = self::ProxyStorage::<T>::get(&proxy_data.proxy);
+			let account_exit = ProxyStorage::<T>::get(&proxy_data.proxy);
 			let bal =
 				proxy_data.max_token_usage.as_ref().map(|&x| x.saturated_into::<BalanceOf<T>>());
 
@@ -102,7 +102,7 @@ pub mod pallet {
 					Self::deposit_event(Event::ProxyAlreadyExist(who));
 				},
 				None => {
-					self::ProxyStorage::<T>::insert(
+					ProxyStorage::<T>::insert(
 						proxy_data.proxy.clone(),
 						ProxyAccStatus {
 							owner: who.clone(),
@@ -129,16 +129,15 @@ pub mod pallet {
 			status: ProxyStatus,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			let account_exit = self::ProxyStorage::<T>::get(&proxy_acc);
+			let account_exit = ProxyStorage::<T>::get(&proxy_acc);
 			match account_exit {
 				Some(acc) => {
 					ensure!(acc.owner == who, Error::<T>::NoPermission);
-					let _ =
-						self::ProxyStorage::<T>::try_mutate(acc.proxy, |proxy| -> DispatchResult {
-							let details = proxy.as_mut().ok_or(Error::<T>::ErrorRef)?;
-							details.status = status;
-							Ok(())
-						});
+					let _ = ProxyStorage::<T>::try_mutate(acc.proxy, |proxy| -> DispatchResult {
+						let details = proxy.as_mut().ok_or(Error::<T>::ErrorRef)?;
+						details.status = status;
+						Ok(())
+					});
 				},
 				None => {
 					Self::deposit_event(Event::ProxyNotExist(who));
@@ -155,11 +154,11 @@ pub mod pallet {
 			proxy_acc: T::AccountId,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			let account_exit = self::ProxyStorage::<T>::get(&proxy_acc);
+			let account_exit = ProxyStorage::<T>::get(&proxy_acc);
 			match account_exit {
 				Some(acc) => {
 					ensure!(acc.owner == who, Error::<T>::NoPermission);
-					self::ProxyStorage::<T>::remove(acc.proxy.clone());
+					ProxyStorage::<T>::remove(acc.proxy.clone());
 
 					Self::deposit_event(Event::ProxyRemoved(acc.proxy));
 				},
@@ -176,7 +175,7 @@ pub mod pallet {
 		pub fn get_proxy_acc(
 			proxy: T::AccountId,
 		) -> Result<GetProxyAcc<T::AccountId, BalanceOf<T>>, DispatchError> {
-			let accounts = self::ProxyStorage::<T>::get(proxy);
+			let accounts = ProxyStorage::<T>::get(proxy);
 
 			Ok(accounts)
 		}
@@ -184,12 +183,12 @@ pub mod pallet {
 
 	impl<T: Config> ProxyExtend<T::AccountId> for Pallet<T> {
 		fn proxy_exist(proxy: T::AccountId) -> bool {
-			let account = self::ProxyStorage::<T>::get(proxy);
+			let account = ProxyStorage::<T>::get(proxy);
 
 			account.is_some()
 		}
 		fn get_master_account(proxy: T::AccountId) -> Option<T::AccountId> {
-			let account = self::ProxyStorage::<T>::get(proxy);
+			let account = ProxyStorage::<T>::get(proxy);
 
 			match account {
 				Some(acc) => Some(acc.owner),
@@ -199,7 +198,7 @@ pub mod pallet {
 
 		fn proxy_update_token_used(proxy: T::AccountId, balance_val: u32) -> bool {
 			let mut exceed_flg = false;
-			let res = self::ProxyStorage::<T>::try_mutate(proxy, |proxy| -> DispatchResult {
+			let res = ProxyStorage::<T>::try_mutate(proxy, |proxy| -> DispatchResult {
 				let details = proxy.as_mut().ok_or(Error::<T>::ErrorRef)?;
 				let max_token_allowed = details.max_token_usage;
 

--- a/pallets/task-metadata/src/lib.rs
+++ b/pallets/task-metadata/src/lib.rs
@@ -86,13 +86,13 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 			let resp = T::ProxyExtend::proxy_exist(who);
 			ensure!(resp, Error::<T>::NotProxyAccount);
-			let data_list = self::TaskMetaStorage::<T>::get(task.collection_id.0);
+			let data_list = TaskMetaStorage::<T>::get(task.collection_id.0);
 			match data_list {
 				Some(val) => {
 					Self::deposit_event(Event::AlreadyExist(val.collection_id.0));
 				},
 				None => {
-					self::TaskMetaStorage::<T>::insert(task.collection_id.0, task.clone());
+					TaskMetaStorage::<T>::insert(task.collection_id.0, task.clone());
 					Self::deposit_event(Event::TaskMetaStored(task.collection_id.0));
 				},
 			}
@@ -109,13 +109,13 @@ pub mod pallet {
 			validity: i64,
 		) -> DispatchResult {
 			let _who = ensure_signed(origin)?;
-			let data_list = self::CollectionMeta::<T>::get(&hash);
+			let data_list = CollectionMeta::<T>::get(&hash);
 			match data_list {
 				Some(val) => {
 					Self::deposit_event(Event::ColAlreadyExist(val.hash));
 				},
 				None => {
-					self::CollectionMeta::<T>::insert(
+					CollectionMeta::<T>::insert(
 						hash.clone(),
 						Collection {
 							hash: hash.clone(),
@@ -136,13 +136,13 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 			let resp = T::ProxyExtend::proxy_exist(who);
 			ensure!(resp, Error::<T>::NotProxyAccount);
-			let data_list = self::PayableTaskMetaStorage::<T>::get(task.collection_id.0);
+			let data_list = PayableTaskMetaStorage::<T>::get(task.collection_id.0);
 			match data_list {
 				Some(val) => {
 					Self::deposit_event(Event::PayableTaskMetaAlreadyExist(val.collection_id.0));
 				},
 				None => {
-					self::PayableTaskMetaStorage::<T>::insert(task.collection_id.0, task.clone());
+					PayableTaskMetaStorage::<T>::insert(task.collection_id.0, task.clone());
 					Self::deposit_event(Event::PayableTaskMetaStorage(task.collection_id.0));
 				},
 			}
@@ -152,24 +152,24 @@ pub mod pallet {
 	}
 	impl<T: Config> Pallet<T> {
 		pub fn get_task_by_key(key: KeyId) -> Result<Option<Task>, DispatchError> {
-			let data_list = self::TaskMetaStorage::<T>::get(key);
+			let data_list = TaskMetaStorage::<T>::get(key);
 			Ok(data_list)
 		}
 
 		pub fn get_tasks() -> Result<Vec<Task>, DispatchError> {
-			let data_list = self::TaskMetaStorage::<T>::iter_values().collect::<Vec<_>>();
+			let data_list = TaskMetaStorage::<T>::iter_values().collect::<Vec<_>>();
 
 			Ok(data_list)
 		}
 
 		pub fn get_tasks_keys() -> Result<Vec<u64>, DispatchError> {
-			let data_list = self::TaskMetaStorage::<T>::iter_keys().collect::<Vec<_>>();
+			let data_list = TaskMetaStorage::<T>::iter_keys().collect::<Vec<_>>();
 
 			Ok(data_list)
 		}
 
 		pub fn get_payable_tasks() -> Result<Vec<PayableTask>, DispatchError> {
-			let data_list = self::PayableTaskMetaStorage::<T>::iter_values().collect::<Vec<_>>();
+			let data_list = PayableTaskMetaStorage::<T>::iter_values().collect::<Vec<_>>();
 
 			Ok(data_list)
 		}
@@ -177,7 +177,7 @@ pub mod pallet {
 		pub fn get_payable_task_metadata_by_key(
 			key: KeyId,
 		) -> Result<Option<PayableTask>, DispatchError> {
-			let data_list = self::PayableTaskMetaStorage::<T>::get(key);
+			let data_list = PayableTaskMetaStorage::<T>::get(key);
 
 			match data_list {
 				Some(val) => Ok(Some(val)),

--- a/pallets/task-schedule/src/lib.rs
+++ b/pallets/task-schedule/src/lib.rs
@@ -104,13 +104,13 @@ pub mod pallet {
 			let master_acc = T::ProxyExtend::get_master_account(who.clone()).unwrap();
 			T::Currency::transfer(&master_acc, &treasury, fix_fee.into(), KeepAlive)?;
 
-			let last_key = self::LastKey::<T>::get();
+			let last_key = LastKey::<T>::get();
 			let schedule_id = match last_key {
 				Some(val) => val.saturating_add(1),
 				None => 1,
 			};
-			self::LastKey::<T>::put(schedule_id);
-			self::ScheduleStorage::<T>::insert(
+			LastKey::<T>::put(schedule_id);
+			ScheduleStorage::<T>::insert(
 				schedule_id,
 				TaskSchedule {
 					task_id: schedule.task_id,
@@ -137,7 +137,7 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 			let resp = T::ProxyExtend::proxy_exist(who.clone());
 			ensure!(resp, Error::<T>::NotProxyAccount);
-			let _ = self::ScheduleStorage::<T>::try_mutate(key, |schedule| -> DispatchResult {
+			let _ = ScheduleStorage::<T>::try_mutate(key, |schedule| -> DispatchResult {
 				let details = schedule.as_mut().ok_or(Error::<T>::ErrorRef)?;
 				ensure!(details.owner == who, Error::<T>::NoPermission);
 
@@ -166,13 +166,13 @@ pub mod pallet {
 			let master_acc = T::ProxyExtend::get_master_account(who.clone()).unwrap();
 			T::Currency::transfer(&master_acc, &treasury, fix_fee.into(), KeepAlive)?;
 
-			let last_key = self::LastKey::<T>::get();
+			let last_key = LastKey::<T>::get();
 			let schedule_id = match last_key {
 				Some(val) => val.saturating_add(1),
 				None => 1,
 			};
-			self::LastKey::<T>::put(schedule_id);
-			self::PayableScheduleStorage::<T>::insert(
+			LastKey::<T>::put(schedule_id);
+			PayableScheduleStorage::<T>::insert(
 				schedule_id,
 				PayableTaskSchedule {
 					task_id: schedule.task_id,
@@ -188,7 +188,7 @@ pub mod pallet {
 	}
 	impl<T: Config> Pallet<T> {
 		pub fn get_schedules() -> Result<ScheduleResults<T::AccountId>, DispatchError> {
-			let data_list = self::ScheduleStorage::<T>::iter()
+			let data_list = ScheduleStorage::<T>::iter()
 				.filter(|item| item.1.status == ScheduleStatus::Initiated)
 				.collect::<Vec<_>>();
 
@@ -197,21 +197,21 @@ pub mod pallet {
 		pub fn get_schedules_by_task_id(
 			key: ObjectId,
 		) -> Result<Vec<TaskSchedule<T::AccountId>>, DispatchError> {
-			let data = self::ScheduleStorage::<T>::iter_values()
+			let data = ScheduleStorage::<T>::iter_values()
 				.filter(|item| item.task_id == key)
 				.collect::<Vec<_>>();
 
 			Ok(data)
 		}
 		pub fn get_schedules_keys() -> Result<Vec<u64>, DispatchError> {
-			let data_list = self::ScheduleStorage::<T>::iter_keys().collect::<Vec<_>>();
+			let data_list = ScheduleStorage::<T>::iter_keys().collect::<Vec<_>>();
 
 			Ok(data_list)
 		}
 		pub fn get_schedule_by_key(
 			key: u64,
 		) -> Result<Option<TaskSchedule<T::AccountId>>, DispatchError> {
-			let data = self::ScheduleStorage::<T>::get(key);
+			let data = ScheduleStorage::<T>::get(key);
 
 			Ok(data)
 		}
@@ -220,7 +220,7 @@ pub mod pallet {
 			status: ScheduleStatus,
 			key: KeyId,
 		) -> Result<(), DispatchError> {
-			let _ = self::ScheduleStorage::<T>::try_mutate(key, |schedule| -> DispatchResult {
+			let _ = ScheduleStorage::<T>::try_mutate(key, |schedule| -> DispatchResult {
 				let details = schedule.as_mut().ok_or(Error::<T>::ErrorRef)?;
 				details.status = status;
 				Ok(())
@@ -231,7 +231,7 @@ pub mod pallet {
 
 		pub fn get_payable_task_schedules(
 		) -> Result<PayableScheduleResults<T::AccountId>, DispatchError> {
-			let data_list = self::PayableScheduleStorage::<T>::iter()
+			let data_list = PayableScheduleStorage::<T>::iter()
 				.filter(|item| item.1.status == ScheduleStatus::Initiated)
 				.collect::<Vec<_>>();
 
@@ -241,7 +241,7 @@ pub mod pallet {
 		pub fn get_payable_schedules_by_task_id(
 			key: ObjectId,
 		) -> Result<Vec<PayableTaskSchedule<T::AccountId>>, DispatchError> {
-			let data = self::PayableScheduleStorage::<T>::iter_values()
+			let data = PayableScheduleStorage::<T>::iter_values()
 				.filter(|item| item.task_id == key)
 				.collect::<Vec<_>>();
 


### PR DESCRIPTION
It is not necessary. Not sure why it was ever added and the convention should not be used anymore for calls to types defined within the local module.