### PR TITLE
Constrain each Shard to Tasks from a single Network

### DIFF
--- a/pallets/task-schedule/src/lib.rs
+++ b/pallets/task-schedule/src/lib.rs
@@ -60,7 +60,7 @@ pub mod pallet {
 			OCWSkdData, ObjectId, PayableScheduleInput, PayableTaskSchedule, ScheduleInput,
 			ScheduleStatus, TaskSchedule,
 		},
-		sharding::{EligibleShard, IncrementTaskTimeoutCount, ReassignShardTasks},
+		sharding::{EligibleShard, IncrementTaskTimeoutCount, Network, ReassignShardTasks},
 		PalletAccounts, ProxyExtend, OCW_SKD_KEY,
 	};
 	pub(crate) type BalanceOf<T> =
@@ -184,7 +184,7 @@ pub mod pallet {
 		type ScheduleFee: Get<BalanceOf<Self>>;
 		type ShouldEndSession: ShouldEndSession<Self::BlockNumber>;
 		type IndexerReward: Get<BalanceOf<Self>>;
-		type ShardEligibility: EligibleShard<u64>;
+		type ShardEligibility: EligibleShard<u64, Network>;
 		type ShardTimeouts: IncrementTaskTimeoutCount<u64>;
 		/// Minimum length in blocks before recurring task is determined to be timed out
 		#[pallet::constant]
@@ -479,7 +479,7 @@ pub mod pallet {
 	impl<T: Config> ReassignShardTasks<u64> for Pallet<T> {
 		fn reassign_shard_tasks(id: u64) {
 			let shard_tasks = ShardTasks::<T>::take(id);
-			let available_shards = T::ShardEligibility::get_eligible_shards(shard_tasks.len());
+			let available_shards = T::ShardEligibility::get_eligible_shards(id, shard_tasks.len());
 			// Reassign all tasks for shard to other shards
 			let mut timed_out_tasks = TimedOutTasks::<T>::get();
 			for (i, key) in shard_tasks.into_iter().enumerate() {

--- a/pallets/tesseract-sig-storage/src/benchmarking.rs
+++ b/pallets/tesseract-sig-storage/src/benchmarking.rs
@@ -5,7 +5,7 @@ use frame_benchmarking::{benchmarks, whitelisted_caller};
 use frame_system::RawOrigin;
 use sp_core::Decode;
 use sp_std::vec;
-use time_primitives::{crypto::Signature, KeyId, ScheduleCycle, TimeId};
+use time_primitives::{crypto::Signature, sharding::Network, KeyId, ScheduleCycle, TimeId};
 
 pub const ALICE: TimeId = TimeId::new([1u8; 32]);
 pub const BOB: TimeId = TimeId::new([2u8; 32]);
@@ -37,7 +37,7 @@ benchmarks! {
 		assert_last_event::<T>(Event::<T>::NewTssGroupKey(s.into(), key).into());
 	}
 
-	register_shard { }: _(RawOrigin::Root, vec![ALICE, BOB, CHARLIE], None)
+	register_shard { }: _(RawOrigin::Root, vec![ALICE, BOB, CHARLIE], None, Network::Ethereum)
 	verify { }
 
 	impl_benchmark_test_suite!(TesseractSigStorage, crate::mock::new_test_ext(), crate::mock::Test);

--- a/pallets/tesseract-sig-storage/src/shard.rs
+++ b/pallets/tesseract-sig-storage/src/shard.rs
@@ -5,7 +5,7 @@ use frame_support::traits::Get;
 use sp_runtime::{traits::Saturating, DispatchError};
 use sp_std::{borrow::ToOwned, vec::Vec};
 use time_primitives::{
-	sharding::{ReassignShardTasks, Shard},
+	sharding::{Network, ReassignShardTasks, Shard},
 	TimeId,
 };
 
@@ -25,18 +25,22 @@ pub struct ShardState {
 	pub committed_offenses_count: u8,
 	/// Status for shard
 	pub status: ShardStatus,
+	/// Network from which tasks assigned to this shard
+	pub net: Network,
 }
 
 impl ShardState {
 	pub fn new<T: Config>(
 		members: Vec<TimeId>,
 		collector_index: Option<u8>,
+		net: Network,
 	) -> Result<ShardState, DispatchError> {
 		Ok(ShardState {
 			shard: new_shard::<T>(members, collector_index)?,
 			task_timeout_count: 0u8,
 			committed_offenses_count: 0u8,
 			status: ShardStatus::Online,
+			net,
 		})
 	}
 	pub fn is_online(&self) -> bool {

--- a/pallets/tesseract-sig-storage/src/tests.rs
+++ b/pallets/tesseract-sig-storage/src/tests.rs
@@ -6,6 +6,7 @@ use sp_core::ConstU32;
 use sp_keystore::Keystore;
 use time_primitives::{
 	abstraction::{ObjectId, ScheduleInput, TaskSchedule as ScheduleOut, Validity},
+	sharding::Network,
 	ScheduleStatus, TimeId,
 };
 
@@ -91,6 +92,7 @@ fn test_signature_storage() {
 			RawOrigin::Root.into(),
 			vec![alice.into(), BOB, CHARLIE],
 			Some(0),
+			Network::Ethereum,
 		),);
 
 		// insert schedule
@@ -167,6 +169,7 @@ fn test_signature_and_decrement_schedule_storage() {
 			RawOrigin::Root.into(),
 			vec![alice.into(), BOB, CHARLIE],
 			Some(0),
+			Network::Ethereum,
 		),);
 
 		// insert schedule
@@ -253,6 +256,7 @@ fn test_duplicate_signature() {
 			RawOrigin::Root.into(),
 			vec![alice.into(), BOB, CHARLIE],
 			Some(0),
+			Network::Ethereum,
 		),);
 
 		// insert schedule
@@ -310,6 +314,7 @@ fn test_register_shard_fails_if_duplicate_members() {
 				RawOrigin::Root.into(),
 				vec![ALICE, BOB, BOB],
 				Some(0),
+				Network::Ethereum,
 			),
 			Error::<Test>::DuplicateShardMembersNotAllowed
 		);
@@ -340,6 +345,7 @@ fn test_register_shard_fails_if_member_len_not_supported() {
 				RawOrigin::Root.into(),
 				vec![ALICE, BOB, CHARLIE, DJANGO],
 				Some(0),
+				Network::Ethereum,
 			),
 			Error::<Test>::UnsupportedMembershipSize
 		);
@@ -377,6 +383,7 @@ fn test_register_shard_works_for_supported_member_lengths() {
 			RawOrigin::Root.into(),
 			members.clone(),
 			Some(1),
+			Network::Ethereum,
 		));
 
 		// supports 5
@@ -386,6 +393,7 @@ fn test_register_shard_works_for_supported_member_lengths() {
 			RawOrigin::Root.into(),
 			members.clone(),
 			Some(1),
+			Network::Ethereum,
 		));
 
 		// supports 10
@@ -406,7 +414,12 @@ fn test_register_shard_works_for_supported_member_lengths() {
 			),);
 			members.push(tmp_time_id);
 		}
-		assert_ok!(TesseractSigStorage::register_shard(RawOrigin::Root.into(), members, Some(1),));
+		assert_ok!(TesseractSigStorage::register_shard(
+			RawOrigin::Root.into(),
+			members,
+			Some(1),
+			Network::Ethereum
+		));
 	});
 }
 
@@ -431,6 +444,7 @@ fn test_register_shard_fails_if_collector_index_invalid() {
 				RawOrigin::Root.into(),
 				vec![ALICE, BOB, CHARLIE],
 				Some(4),
+				Network::Ethereum,
 			),
 			Error::<Test>::CollectorIndexBeyondMemberLen
 		);
@@ -465,6 +479,7 @@ fn test_report_misbehavior_increments_report_count() {
 			RawOrigin::Root.into(),
 			vec![alice.into(), bob.into(), CHARLIE],
 			Some(0),
+			Network::Ethereum,
 		));
 
 		// report 1st offence
@@ -519,6 +534,7 @@ fn test_report_misbehavior_updates_reporters() {
 			RawOrigin::Root.into(),
 			vec![alice.into(), bob.into(), CHARLIE],
 			Some(0),
+			Network::Ethereum,
 		));
 
 		// report 1st offence
@@ -578,6 +594,7 @@ fn test_report_misbehavior_moves_offences_to_committed() {
 			RawOrigin::Root.into(),
 			vec![alice.into(), bob.into(), CHARLIE],
 			Some(0),
+			Network::Ethereum,
 		));
 		// To report offence, need to sign the public key
 
@@ -645,6 +662,7 @@ fn test_report_misbehavior_for_group_len_5() {
 			RawOrigin::Root.into(),
 			vec![ALICE, BOB, charlie.into(), david.into(), edward.into()],
 			Some(2),
+			Network::Ethereum,
 		));
 		// To report offence, need to sign the public key
 
@@ -757,6 +775,7 @@ fn test_report_misbehavior_for_group_len_10() {
 				jared.into()
 			],
 			Some(4),
+			Network::Ethereum,
 		));
 		// To report offence, need to sign the public key
 
@@ -848,6 +867,7 @@ fn can_report_offence_if_already_committed_offender() {
 			RawOrigin::Root.into(),
 			vec![ALICE, bob.into(), charlie.into(), david.into(), edward.into()],
 			Some(1),
+			Network::Ethereum,
 		));
 
 		// report 1st offence

--- a/primitives/time-primitives/src/sharding.rs
+++ b/primitives/time-primitives/src/sharding.rs
@@ -20,19 +20,31 @@ pub trait IncrementTaskTimeoutCount<Id> {
 	fn increment_task_timeout_count(_id: Id) {}
 }
 impl<Id> IncrementTaskTimeoutCount<Id> for () {}
-/// Expose shard eligibility
-pub trait EligibleShard<Id> {
+/// Expose shard eligibility for specific networks
+pub trait EligibleShard<Id, Network> {
 	fn is_eligible_shard(id: Id) -> bool;
-	fn get_eligible_shards(n: usize) -> Vec<Id>;
+	fn is_eligible_shard_for_network(id: Id, net: Network) -> bool;
+	fn get_eligible_shards(id: Id, n: usize) -> Vec<Id>;
 }
-impl<Id> EligibleShard<Id> for () {
+impl<Id, Network> EligibleShard<Id, Network> for () {
 	fn is_eligible_shard(_id: Id) -> bool {
 		// all shards eligible by default for testing purposes
 		true
 	}
-	fn get_eligible_shards(_n: usize) -> Vec<Id> {
+	fn is_eligible_shard_for_network(_id: Id, _net: Network) -> bool {
+		// all shards eligible by default for testing purposes
+		true
+	}
+	fn get_eligible_shards(_id: Id, _n: usize) -> Vec<Id> {
 		Vec::default()
 	}
+}
+
+/// Used to enforce one network per shard
+#[derive(Debug, Copy, Clone, Encode, Decode, TypeInfo, PartialEq)]
+pub enum Network {
+	Ethereum,
+	Astar,
 }
 
 /// Enum representing sizes of shards available


### PR DESCRIPTION
This PR 
- [x] constrains each shard to tasks from one network: `enum Network { Ethereum, Astar }`
- [x] reassign all tasks for shard to only shards assigned to the same network i.e. tasks assigned to a shard constrained to Network::Ethereum are only reassigned to active shards of Network::Ethereum

Follow ups include:
* specify Network as argument for insert_schedule instead of ShardId and by default put all tasks into an unassigned queue, to be claimed by shards of that type in a separate extrinsic
* consider constraining all tasks to one Shard Size similar to constraining them to one network (so all tasks assigned to Shard of size 3 are always reassigned to shards of the same size as well)
* consider adding extrinsic to change the Network for a shard (only callable by collector and would imply reassigning shard's existing tasks from old network to other shards for that network)