### PR TITLE
set shard online after tss key generated

### DIFF
--- a/pallets/tesseract-sig-storage/src/lib.rs
+++ b/pallets/tesseract-sig-storage/src/lib.rs
@@ -319,6 +319,9 @@ pub mod pallet {
 
 		///no local account for signed tx
 		NoLocalAcctForSignedTx,
+
+		/// Error getting schedule ref.
+		ErrorRef,
 	}
 
 	#[pallet::inherent]
@@ -453,6 +456,11 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			ensure_none(origin)?;
 			<TssGroupKey<T>>::insert(set_id, group_key);
+			<TssShards<T>>::try_mutate(set_id, |shard_state| -> DispatchResult {
+				let details = shard_state.as_mut().ok_or(Error::<T>::ErrorRef)?;
+				details.status = ShardStatus::Online;
+				Ok(())
+			})?;
 			Self::deposit_event(Event::NewTssGroupKey(set_id, group_key));
 
 			Ok(().into())

--- a/pallets/tesseract-sig-storage/src/shard.rs
+++ b/pallets/tesseract-sig-storage/src/shard.rs
@@ -39,7 +39,7 @@ impl ShardState {
 			shard: new_shard::<T>(members, collector_index)?,
 			task_timeout_count: 0u8,
 			committed_offenses_count: 0u8,
-			status: ShardStatus::Online,
+			status: ShardStatus::Offline,
 			net,
 		})
 	}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1509,7 +1509,6 @@ impl_runtime_apis! {
 			TesseractSigStorage::inactive_shards()
 		}
 
-
 		fn get_shard_tasks(shard_id: u64) -> Vec<KeyId> {
 			TaskSchedule::shard_tasks(shard_id)
 		}


### PR DESCRIPTION
## Description

**Problem:**
  If group key is not generated and we execute a task (Happens when you executed a task just after registering shard), It panics and nodes stop functioning with error `Invalid State`.
**Solution:**
  Sets Shard status online when tss group key is generated and nodes are ready for tss process.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Tests

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Manual Test

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code changes introduces no new problems or warnings