### PR TITLE
Fix workflow input of env to choice

### DIFF
--- a/.github/workflows/deploy-cluster.yaml
+++ b/.github/workflows/deploy-cluster.yaml
@@ -21,7 +21,7 @@ on:
       environment:
         description: "Target environment where to fetch secrets and vars"
         required: true
-        type: string
+        type: choice
         options:
           - "internal"
 


### PR DESCRIPTION
## Description

- fixed input of `Deploy to K8s cluster` to choice (to avoid targeting non-existing clusters)