### PR TITLE
Change bootnode-2 port

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -318,7 +318,7 @@ pub fn analog_testnet_config() -> Result<ChainSpec, String> {
 		// Bootnodes
 		vec![
 			"/dns/bootnode-1.internal.analog.one/tcp/30333/p2p/12D3KooWHRZcA2GHQYpbqwPsvk3ZEPDnu35w7cfEBxYPFfTR2bHX".parse().unwrap(),
-			"/dns/bootnode-2.internal.analog.one/tcp/30333/p2p/12D3KooWAHTG5KqRPKyerDVXAVrGEXd3g1XDK9JajbTCZP2K7xVN".parse().unwrap(),
+			"/dns/bootnode-2.internal.analog.one/tcp/30334/p2p/12D3KooWAHTG5KqRPKyerDVXAVrGEXd3g1XDK9JajbTCZP2K7xVN".parse().unwrap(),
 		],
 		// Telemetry
 		None,


### PR DESCRIPTION
Bootnode-2 port changed because of cluster conflict

## Description

Port for bootnode-2 changed from 30333 to 30334

## Type of change

- chain spec for internal network