### PR TITLE
Sleep in payable-task-executor if keys are not found

### DIFF
--- a/workers/payable-task-executor/src/worker.rs
+++ b/workers/payable-task-executor/src/worker.rs
@@ -297,11 +297,8 @@ where
 				} else {
 					log::error!("Blockchain is empty");
 				}
-				sleep(delay).await;
-			} else {
-				log::error!("No keys found");
-				break;
 			}
+			sleep(delay).await;
 		}
 	}
 }


### PR DESCRIPTION
Try patch #317 or part of it. Authored by @dvc94ch 

Move sleep to the end of the loop 