### PR TITLE
Add ca-certificates inside Docker image

### DIFF
--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -13,6 +13,7 @@ FROM ubuntu:22.04
 
 ## TODO: change repo name to timechain
 ## TODO: add a documentation label
+RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 LABEL description="Multistage Dockerfile for building Analog Timechain" \
 	one.analog.image.type="builder" \


### PR DESCRIPTION
## Description

Added `ca-certificates` inside timechain Docker image.

Fixes # (issue)

Fixing SSL certificate validation. Related to #321 
