### PR TITLE
Bound min and max len for shards membership

### DIFF
--- a/pallets/shards/src/lib.rs
+++ b/pallets/shards/src/lib.rs
@@ -34,6 +34,10 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 		type ShardCreated: ShardCreated;
 		type TaskScheduler: ScheduleInterface;
+		#[pallet::constant]
+		type MaxMembers: Get<u8>;
+		#[pallet::constant]
+		type MinMembers: Get<u8>;
 	}
 
 	#[pallet::storage]
@@ -66,7 +70,8 @@ pub mod pallet {
 	pub enum Error<T> {
 		UnknownShard,
 		PublicKeyAlreadyRegistered,
-		InvalidNumberOfShardMembers,
+		MembershipBelowMinimum,
+		MembershipAboveMaximum,
 	}
 
 	#[pallet::call]
@@ -85,7 +90,14 @@ pub mod pallet {
 			collector: PublicKey,
 		) -> DispatchResult {
 			ensure_root(origin)?;
-			ensure!(members.len() >= 3, Error::<T>::InvalidNumberOfShardMembers);
+			ensure!(
+				members.len() >= T::MinMembers::get().into(),
+				Error::<T>::MembershipBelowMinimum
+			);
+			ensure!(
+				members.len() <= T::MaxMembers::get().into(),
+				Error::<T>::MembershipAboveMaximum
+			);
 			let shard_id = <ShardIdCounter<T>>::get();
 			<ShardIdCounter<T>>::put(shard_id + 1);
 			<ShardNetwork<T>>::insert(shard_id, network);

--- a/pallets/shards/src/mock.rs
+++ b/pallets/shards/src/mock.rs
@@ -1,5 +1,5 @@
 use crate::{self as pallet_shards};
-use sp_core::{ConstU128, ConstU16, ConstU32, ConstU64, H256};
+use sp_core::{ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, H256};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
@@ -85,6 +85,8 @@ impl pallet_shards::Config for Test {
 	type WeightInfo = pallet_shards::weights::WeightInfo<Test>;
 	type ShardCreated = MockOcw;
 	type TaskScheduler = MockTaskScheduler;
+	type MaxMembers = ConstU8<20>;
+	type MinMembers = ConstU8<3>;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1152,6 +1152,8 @@ impl pallet_shards::Config for Runtime {
 	type WeightInfo = pallet_shards::weights::WeightInfo<Runtime>;
 	type ShardCreated = Ocw;
 	type TaskScheduler = Tasks;
+	type MaxMembers = ConstU8<20>;
+	type MinMembers = ConstU8<3>;
 }
 
 impl pallet_tasks::Config for Runtime {


### PR DESCRIPTION
Bound shard membership size with shard Config constants

Bounds maximum shard length to 20 and minimum to 3. We can change these, but the upper bound definitely must exist for safety.