### PR TITLE
ocw fix error on race condition

### DIFF
--- a/pallets/ocw/src/lib.rs
+++ b/pallets/ocw/src/lib.rs
@@ -163,7 +163,7 @@ pub mod pallet {
 						Err(())
 					}
 				})
-				.unwrap()
+				.unwrap_or_default()
 		}
 
 		pub(crate) fn read_message() -> Option<OcwPayload> {


### PR DESCRIPTION
## Description

Fix wasm error of ValueFunctionFailed() on race condition.
error:
```
2023-08-26 01:23:48.136 ERROR      offchain-worker offchain-worker: Error running offchain workers at 0x0afec567c54c6ba10fac085bf059f20519c00e2d3df434c4452171f8f59bb872: Execution failed: Execution aborted due to trap: wasm trap: wasm `unreachable` instruction executed
WASM backtrace:
error while executing at wasm backtrace:
    0: 0x37fab - <unknown>!rust_begin_unwind
    1: 0x3dca - <unknown>!core::panicking::panic_fmt::h8a19fa1eb63fbb67
    2: 0x42ce - <unknown>!core::result::unwrap_failed::h11ff2abd8d53a5bd
    3: 0x1c2c9e - <unknown>!<pallet_ocw::pallet::Pallet<T> as frame_support::traits::misc::OffchainWorker<<<<T as frame_system::pallet::Config>::Block as sp_runtime::traits::HeaderProvider>::HeaderT as sp_runtime::traits::Header>::Number>>::offchain_worker::h996ad5ce87e7d69f
    4: 0x1f308a - <unknown>!<(TupleElement0,TupleElement1,TupleElement2,TupleElement3,TupleElement4,TupleElement5,TupleElement6,TupleElement7,TupleElement8,TupleElement9,TupleElement10,TupleElement11,TupleElement12,TupleElement13,TupleElement14,TupleElement15,TupleElement16,TupleElement17,TupleElement18,TupleElement19,TupleElement20) as frame_support::traits::misc::OffchainWorker<BlockNumber>>::offchain_worker::h27e629299304d406
    5: 0x1b91e4 - <unknown>!frame_executive::Executive<System,Block,Context,UnsignedValidator,AllPalletsWithSystem,COnRuntimeUpgrade>::offchain_worker::h8d608d102bfc1d81
    6: 0xd1da1 - <unknown>!OffchainWorkerApi_offchain_worker
```