### PR TITLE
reduces oneshot errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,7 +177,7 @@ services:
     - "host.docker.internal:host-gateway"
 
   ethereum:
-    image: "ethereum/client-go:v1.10.26"
+    image: "ethereum/client-go:v1.12.2"
     command: "--dev --ipcdisable --dev.period 14 --http --http.addr 0.0.0.0 --http.vhosts * --http.api eth,debug,admin,txpool,web3"
     expose:
     - "8545"

--- a/js/src/add_task_eth.js
+++ b/js/src/add_task_eth.js
@@ -29,14 +29,14 @@ const pallet_task_add = async (_keyspair, who) => {
     const input_task = {
         network: 0,
         cycle: 4,
-        start: 0,
+        start: 11,
         period: 2,
         hash: 'QmYFw5aYPKQ9oSw3L3UUed9fBqT4oTW5BZzAnPFGyuQir3',
         function: {
             EVMViewWithoutAbi: {
                 address: stringToHex('0x3de7086ce750513ef79d14eacbd1282c4e4b0cea'),
                 function_signature: "function get_votes_stats() external view returns (uint[] memory)",
-                input: 2,
+                input: [],
             }
         },
     }

--- a/primitives/src/shard.rs
+++ b/primitives/src/shard.rs
@@ -1,4 +1,4 @@
-use crate::{TaskCycle, TaskId, TaskRetryCount};
+use crate::{TaskCycle, TaskId};
 use codec::{Decode, Encode};
 #[cfg(feature = "std")]
 use futures::channel::oneshot;
@@ -11,7 +11,8 @@ pub type TssPublicKey = [u8; 33];
 pub type TssSignature = [u8; 64];
 pub type PeerId = [u8; 32];
 pub type ShardId = u64;
-pub type TssId = (TaskId, TaskCycle, TaskRetryCount);
+pub type BlockNum = u64;
+pub type TssId = (TaskId, TaskCycle, BlockNum);
 
 /// Used to enforce one network per shard
 #[cfg_attr(feature = "std", derive(Serialize))]

--- a/primitives/src/task.rs
+++ b/primitives/src/task.rs
@@ -99,7 +99,6 @@ pub trait TaskSpawner {
 		shard_id: ShardId,
 		task_id: TaskId,
 		cycle: TaskCycle,
-		retry_count: TaskRetryCount,
 		task: TaskDescriptor,
 		block_num: u64,
 	) -> Pin<Box<dyn Future<Output = Result<TssSignature>> + Send + 'static>>;

--- a/workers/task-executor/src/tests.rs
+++ b/workers/task-executor/src/tests.rs
@@ -15,7 +15,7 @@ use std::{future::Future, pin::Pin};
 use substrate_test_runtime_client::ClientBlockImportExt;
 use time_primitives::{
 	Function, Network, OcwPayload, PeerId, ShardId, TaskCycle, TaskDescriptor, TaskExecution,
-	TaskId, TaskRetryCount, TaskSpawner, TimeApi, TssSignature,
+	TaskId, TaskSpawner, TimeApi, TssSignature,
 };
 
 #[derive(Clone, Default)]
@@ -80,7 +80,6 @@ impl TaskSpawner for MockTask {
 		_shard_id: ShardId,
 		_task_id: TaskId,
 		_cycle: TaskCycle,
-		_retry_count: TaskRetryCount,
 		_task: TaskDescriptor,
 		_block_num: u64,
 	) -> Pin<Box<dyn Future<Output = Result<TssSignature>> + Send + 'static>> {

--- a/workers/task-executor/src/worker.rs
+++ b/workers/task-executor/src/worker.rs
@@ -16,7 +16,7 @@ use std::{
 };
 use time_primitives::{
 	CycleStatus, Function, OcwPayload, PeerId, ShardId, TaskCycle, TaskDescriptor, TaskError,
-	TaskExecution, TaskId, TaskRetryCount, TaskSpawner, TimeApi, TssRequest, TssSignature,
+	TaskExecution, TaskId, TaskSpawner, TimeApi, TssRequest, TssSignature,
 };
 use timegraph_client::{Timegraph, TimegraphData};
 
@@ -103,7 +103,7 @@ impl Task {
 		shard_id: ShardId,
 		task_id: TaskId,
 		cycle: TaskCycle,
-		retry_count: TaskRetryCount,
+		block_num: u64,
 		result: &[String],
 	) -> Result<TssSignature> {
 		let data = bincode::serialize(&result).context("Failed to serialize task")?;
@@ -111,7 +111,7 @@ impl Task {
 		self.tss
 			.clone()
 			.send(TssRequest {
-				request_id: (task_id, cycle, retry_count),
+				request_id: (task_id, cycle, block_num),
 				shard_id,
 				data,
 				tx,
@@ -126,7 +126,6 @@ impl Task {
 		shard_id: ShardId,
 		task_id: TaskId,
 		task_cycle: TaskCycle,
-		retry_count: TaskRetryCount,
 		task: TaskDescriptor,
 		block_num: u64,
 	) -> Result<TssSignature> {
@@ -135,7 +134,7 @@ impl Task {
 			.await
 			.with_context(|| format!("Failed to execute {:?}", task.function))?;
 		let signature = self
-			.tss_sign(shard_id, task_id, task_cycle, retry_count, &result)
+			.tss_sign(shard_id, task_id, task_cycle, block_num, &result)
 			.await
 			.with_context(|| format!("Failed to tss sign on shard {}", shard_id))?;
 		if let Some(timegraph) = self.timegraph.as_ref() {
@@ -170,15 +169,12 @@ impl TaskSpawner for Task {
 		shard_id: ShardId,
 		task_id: TaskId,
 		cycle: TaskCycle,
-		retry_count: TaskRetryCount,
 		task: TaskDescriptor,
 		block_num: u64,
 	) -> Pin<Box<dyn Future<Output = Result<TssSignature>> + Send + 'static>> {
 		self.clone()
-			.execute(target_block, shard_id, task_id, cycle, retry_count, task, block_num)
-			.map(move |res| {
-				res.with_context(|| format!("Task {}/{}/{} failed", task_id, cycle, retry_count))
-			})
+			.execute(target_block, shard_id, task_id, cycle, task, block_num)
+			.map(move |res| res.with_context(|| format!("Task {}/{} failed", task_id, cycle)))
 			.boxed()
 	}
 }
@@ -236,7 +232,6 @@ where
 			for executable_task in tasks.iter().copied() {
 				let task_id = executable_task.task_id;
 				let cycle = executable_task.cycle;
-				let retry_count = executable_task.retry_count;
 				if self.running_tasks.contains(&executable_task) {
 					log::info!("skipping task {:?}", executable_task);
 					if let Some(executed_block_num) = self.execution_block_map.get(&executable_task)
@@ -260,7 +255,6 @@ where
 						shard_id,
 						task_id,
 						cycle,
-						retry_count,
 						task_descr,
 						block_num,
 					);


### PR DESCRIPTION
## Description

Helps have a Unique session-id everyime which reduces one-shot errors:

**Note:** Not a proper solution but a patch to reduce number of task failures in staging. Since proper solution si already in development branch and migrating will take alot of time.

**Constraints:**
 Tss process will pass between nodes when all nodes ran the task on same block of local chain. If tasks cycle is ran on different block the tss process will fail since the session-id will not match.