### PR TITLE
Modify release Docker base image

### DIFF
--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,5 +1,6 @@
 ### Build stage
-FROM docker.io/paritytech/ci-linux:production as builder
+### Uses custom substrate builder (Dockerfile in infra repo)
+FROM analoglabs/substrate-builder:latest as builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Description

Base image for production Dockerfile uses custom builder. The builder's Dockerfile is located in the infrastructure repo.

Fixes #496 

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed