### PR TITLE
Set chain spec in docker compose.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: 'analoglabs/timechain-node'
     command:
     - '--base-path=/data'
-    - '--chain=notss'
+    - '--chain=${CHAIN_SPEC}'
     - '--rpc-cors=all'
     - '--unsafe-rpc-external'
     - '--rpc-methods=unsafe'
@@ -50,7 +50,7 @@ services:
     image: 'analoglabs/timechain-node'
     command:
     - '--base-path=/data'
-    - '--chain=notss'
+    - '--chain=${CHAIN_SPEC}'
     - '--rpc-cors=all'
     - '--unsafe-rpc-external'
     - '--rpc-methods=unsafe'
@@ -77,7 +77,7 @@ services:
     image: 'analoglabs/timechain-node'
     command:
     - '--base-path=/data'
-    - '--chain=notss'
+    - '--chain=${CHAIN_SPEC}'
     - '--rpc-cors=all'
     - '--unsafe-rpc-external'
     - '--rpc-methods=unsafe'


### PR DESCRIPTION
to run with tss enabled start the chain with `CHAIN_SPEC=dev docker compose --profile ethereum up --scale chronicle-eth=3` to run without `CHAIN_SPEC=notss docker compose --profile ethereum up`.

default chain spec is still dev, maybe we should change it to notss.