### PR TITLE
Change srtool image when building the runtime

### DIFF
--- a/.github/workflows/build-runtime.yaml
+++ b/.github/workflows/build-runtime.yaml
@@ -35,7 +35,8 @@ jobs:
         id: srtool_build
         uses: chevdor/srtool-actions@v0.7.0
         with:
-          image: paritytech/srtool
+          image: analoglabs/srtool
+          tag: 1.72.1
           chain: timechain
           runtime_dir: "runtime"
 


### PR DESCRIPTION
## Description

Change the build image from `paritytech/srtool:1.69.0` to `analoglabs/srtool:1.72.1`.

The updated image has the srtool built with Rust 1.72.1 which builds the runtime WASM consistent and correctly. The previous image results in build errors.