### PR TITLE
Update substrate builder image

### DIFF
--- a/config/docker/Dockerfile.release
+++ b/config/docker/Dockerfile.release
@@ -6,7 +6,7 @@ WORKDIR /build
 
 COPY . .
 
-RUN cargo build --locked --release
+RUN cargo build -p timechain-node --locked --release
 
 ### Release stage
 # Copies the binary from the builder stage into a fresh scratch image


### PR DESCRIPTION
## Description

- updates the substrate builder and Rust version
- builds the timechain Docker image only for the timechain-node project