### PR TITLE
Require gateway fees burned at GMP task creation

### DIFF
--- a/pallets/tasks/src/mock.rs
+++ b/pallets/tasks/src/mock.rs
@@ -127,6 +127,8 @@ impl task_schedule::Config for Test {
 	type WritePhaseTimeout = ConstU64<10>;
 	type ReadPhaseTimeout = ConstU64<20>;
 	type PalletId = PalletIdentifier;
+	// TODO: set equal to 1 * Min Shard Size for full testing
+	type GatewayFee = ConstU128<1>;
 }
 
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Test


### PR DESCRIPTION
Closes #729 

AFAIU we had agreed to burn the gateway fees for `SendMessage` tasks regardless of the task outcome (`submit_{err, result}`).  If we burn the gateway fees for every outcome of `SendMessage` tasks, might as well require burning the gateway fees at task creation of `SendMessage` tasks.

TODOs iff this solution is chosen:
- [ ] if GMP task is (Un)RegisterShard, burn gateway fee from shard stake
- [ ] update integration test requiring shard stake min requirement to include gateway fee requirement