### PR TITLE
Fix reimbursement to exactly match `gateway.execute` gas cost measured by `testExecuteReimbursement`

### DIFF
--- a/contracts/gateway.sol
+++ b/contracts/gateway.sol
@@ -228,6 +228,8 @@ contract Gateway is IGateway, SigUtils {
     uint8 internal constant SHARD_ACTIVE = (1 << 0); // Shard active bitflag
     uint8 internal constant SHARD_Y_PARITY = (1 << 1); // Pubkey y parity bitflag
 
+    uint256 internal constant EXECUTE_GAS_DIFF = 10630; // Measured gas cost difference for `execute`
+
     // Owner of this contract, who can execute sudo operations
     address _owner;
 
@@ -493,7 +495,7 @@ contract Gateway is IGateway, SigUtils {
         bytes32 messageHash = getGmpTypedHash(message);
         _verifySignature(signature, messageHash);
         (status, result) = _execute(messageHash, message);
-        uint256 refund = (gasBefore - gasleft()) * tx.gasprice;
+        uint256 refund = (gasBefore - gasleft() + EXECUTE_GAS_DIFF) * tx.gasprice;
         _deposits[message.source][message.srcNetwork] = _deposits[message.source][message.srcNetwork] - refund;
         payable(tx.origin).transfer(refund);
     }

--- a/contracts/gateway.t.sol
+++ b/contracts/gateway.t.sol
@@ -19,7 +19,7 @@ contract GatewayTest is Test {
         keys[0] = [signer.yParity() == 28 ? 1 : 0, signer.xCoord()];
         gateway = new Gateway(keys);
         FOUNDRY_GAS_LIMIT = 9223372036854775807;
-        EXECUTE_CALL_COST = 41207; // verified in testExecuteReimbursement
+        EXECUTE_CALL_COST = 51840;
     }
 
     function sign(GmpMessage memory gmp) internal view returns (Signature memory) {
@@ -252,11 +252,11 @@ contract GatewayTest is Test {
         Signature memory sig = sign(gmp);
         uint256 gasBefore = gasleft();
         (uint8 status,) = gateway.execute(sig, gmp);
+        uint256 expectedRefund = (gasBefore - gasleft()) * tx.gasprice;
         uint8 GMP_STATUS_SUCCESS = 1;
         assertEq(status, GMP_STATUS_SUCCESS);
         uint256 actualRefund = mockSender.balance - amount;
         assertEq(amount - gatewayAddress.balance, actualRefund);
-        uint256 expectedRefund = ((gasBefore - gasleft()) * tx.gasprice) - 11072;
         assertEq(actualRefund, expectedRefund);
         assertEq(actualRefund, EXECUTE_CALL_COST);
         vm.stopPrank();


### PR DESCRIPTION
The prior reimbursement underestimated the gas cost of `execute` by not accounting for the cost of the reimbursement transfer itself. This PR corrects that mistake.

Before we were not accounting for some gas cost for the reimbursement. We had subtracted this unaccounted gas cost from what was measured by the tests as the cost for `execute` to match what was actually transferred for the reimbursement. But the correct solution is to increase the reimbursement to match the gas cost measured by `execute` in the test.