### PR TITLE
Prevent StakeBelowTransfer error from causing runtime panic

### DIFF
--- a/pallets/tasks/src/lib.rs
+++ b/pallets/tasks/src/lib.rs
@@ -833,12 +833,17 @@ pub mod pallet {
 
 	impl<T: Config> TasksInterface for Pallet<T> {
 		fn shard_online(shard_id: ShardId, network: NetworkId) {
+			let add_shard = |shard, net| {
+				NetworkShards::<T>::insert(net, shard, ());
+				Self::schedule_tasks(net);
+			};
 			if Gateway::<T>::get(network).is_some() {
 				if Self::register_shard(shard_id, network).is_ok() {
-					NetworkShards::<T>::insert(network, shard_id, ());
-					Self::schedule_tasks(network);
+					add_shard(shard_id, network);
 				} // else silent failure
-			} // else silent failure
+			} else {
+				add_shard(shard_id, network);
+			}
 		}
 
 		fn shard_offline(shard_id: ShardId, network: NetworkId) {


### PR DESCRIPTION
Closes #759 by not panicking the runtime if the Register/Unregister task creation fails.

The complexity of preventing the panic stems from the fact that shard_online/offline automatically create Register/Unregister tasks funded by the shard members' stake. If they run out of stake, the task creation panics.

This PR doe not persist storage changes associated with task creation success unless the task is properly funded.