### PR TITLE
Fix tester panic in `get_shard_id` on Offline shards

### DIFF
--- a/tester/src/lib.rs
+++ b/tester/src/lib.rs
@@ -145,7 +145,7 @@ impl Tester {
 				Err(err) => {
 					println!("Skipping shard_id {shard_id}: {err}");
 					continue;
-				}
+				},
 			};
 		}
 		Ok(None)


### PR DESCRIPTION
## Description

In case the first online shard has a non-zero ID, the tester would panic, because shard_network is only present on shards that are Online. This PR prints out the error and skips the currently observed shard.