### PR TITLE
Add redeploy flag in tester SetupGmp

### DIFF
--- a/tester/src/lib.rs
+++ b/tester/src/lib.rs
@@ -9,6 +9,7 @@ use std::process::Command;
 use std::time::Duration;
 use tc_subxt::timechain_runtime::tasks::events::{GatewayRegistered, TaskCreated};
 use tc_subxt::{SubxtClient, SubxtTxSubmitter};
+use time_primitives::sp_core::H160;
 use time_primitives::{
 	sp_core, Function, IGateway, Msg, NetworkId, Runtime, ShardId, TaskDescriptorParams, TaskId,
 	TaskPhase, TssKey, TssPublicKey,
@@ -247,9 +248,12 @@ impl Tester {
 		self.wait_for_task(task_id).await
 	}
 
-	pub async fn setup_gmp(&self) -> Result<[u8; 20]> {
-		if let Some(gateway) = self.runtime.get_gateway(self.network_id).await? {
-			return Ok(gateway);
+	pub async fn setup_gmp(&self, redeploy: bool) -> Result<[u8; 20]> {
+		if !redeploy {
+			if let Some(gateway) = self.runtime.get_gateway(self.network_id).await? {
+				println!("Gateway contract already deployed at {:?}. If you want to redeploy, please use the --redeploy flag.", H160::from_slice(&gateway[..]));
+				return Ok(gateway);
+			}
 		}
 		let shard_id = self.wait_for_shard().await?;
 		let shard_public_key = self.runtime.shard_public_key(shard_id).await.unwrap();

--- a/tester/src/main.rs
+++ b/tester/src/main.rs
@@ -46,7 +46,11 @@ const GATEWAY_EXECUTE_GAS_COST: u128 = 100_000;
 #[derive(Parser, Debug)]
 enum TestCommand {
 	FundWallet,
-	SetupGmp,
+	SetupGmp {
+		/// Deploys and registers a new gateway contract even, replacing the existing one.
+		#[clap(long, short = 'r', default_value_t = false)]
+		redeploy: bool,
+	},
 	WatchTask {
 		task_id: u64,
 	},
@@ -89,8 +93,8 @@ async fn main() -> Result<()> {
 		TestCommand::FundWallet => {
 			tester.faucet().await;
 		},
-		TestCommand::SetupGmp => {
-			tester.setup_gmp().await?;
+		TestCommand::SetupGmp { redeploy } => {
+			tester.setup_gmp(redeploy).await?;
 		},
 		TestCommand::WatchTask { task_id } => {
 			tester.wait_for_task(task_id).await;
@@ -313,7 +317,7 @@ async fn latency_cycle(
 
 async fn test_setup(tester: &Tester, contract: &Path) -> Result<([u8; 20], [u8; 20], u64)> {
 	tester.faucet().await;
-	let gmp_contract = tester.setup_gmp().await?;
+	let gmp_contract = tester.setup_gmp(false).await?;
 	let (contract, start_block) = tester
 		.deploy(contract, VotingContract::constructorCall { _gateway: gmp_contract.into() })
 		.await?;
@@ -360,7 +364,7 @@ async fn batch_test(tester: &Tester, contract: &Path, total_tasks: u64) -> Resul
 
 async fn gmp_test(tester: &Tester, contract: &Path) -> Result<()> {
 	tester.faucet().await;
-	let gmp_contract = tester.setup_gmp().await?;
+	let gmp_contract = tester.setup_gmp(false).await?;
 	let (contract1, _) = tester
 		.deploy(contract, VotingContract::constructorCall { _gateway: gmp_contract.into() })
 		.await?;


### PR DESCRIPTION
## Description

Added the `--redeploy` flag on the SetupGmp command. This one is needed if the user needs to redeploy a new contract if there's already one deployed and registered.