### PR TITLE
Increase heartbeat timeout in runtime only

### DIFF
--- a/chronicle/src/shards/service.rs
+++ b/chronicle/src/shards/service.rs
@@ -350,8 +350,8 @@ where
 		);
 
 		let min_block_time = self.substrate.get_block_time_in_ms().await.unwrap();
-		let raw_frequency = self.substrate.get_heartbeat_timeout().await.unwrap();
-		let heartbeat_time = (raw_frequency - (raw_frequency / 10)) * min_block_time;
+		let heartbeat_time =
+			(self.substrate.get_heartbeat_timeout().await.unwrap() / 2) * min_block_time;
 		let heartbeat_duration = Duration::from_millis(heartbeat_time);
 		let mut heartbeat_tick =
 			interval_at(Instant::now() + heartbeat_duration, heartbeat_duration);


### PR DESCRIPTION
Closes #783 to decrease the bloat of heartbeat transactions

Following @FlorianFranzen 's [recommendation](https://github.com/Analog-Labs/timechain/pull/787#issuecomment-2014337944):
1. Increases timeout to every 30 minutes (300 blocks)

Consequence of this change is it takes longer to detect when a member/shard is offline (to reassign their tasks to online shards).

Follow up made #793 for:
2. Updates chronicle heartbeat submission to leave 10% of time remaining instead of 50%