### PR TITLE
Add paths-ignore for chronicle

### DIFF
--- a/.github/workflows/build-docker-chronicle.yaml
+++ b/.github/workflows/build-docker-chronicle.yaml
@@ -2,10 +2,13 @@ name: Build Docker chronicle image
 
 on:
   push:
-    paths:
-      - 'chronicle/**'
-      - 'tss/**'
-      - 'tc-subxt/**'
+    paths-ignore:
+      - 'contracts/**'
+      - '**/*.md'
+      - 'scripts/**'
+      - 'utils/**'
+      - 'tester/**'
+      - 'node/**'
     branches:
       - 'development'
 


### PR DESCRIPTION
## Description

Ignores unused paths for chronicle build (instead of the old way of including and missing something like the metadata.scale file)