### PR TITLE
ss58: add custom prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13646,9 +13646,8 @@ dependencies = [
 
 [[package]]
 name = "ss58-registry"
-version = "1.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4743ce898933fbff7bbf414f497c459a782d496269644b3d650a398ae6a487ba"
+version = "1.48.0"
+source = "git+https://github.com/Analog-Labs/ss58-registry.git#db1f1a72cb15b3ead80b3679b13620da89b691b5"
 dependencies = [
  "Inflector",
  "num-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ debug = true
 [profile.release-codecov]
 inherits = "release"
 strip = false
+
+[patch.crates-io]
+ss58-registry = { git = 'https://github.com/Analog-Labs/ss58-registry.git' }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -288,7 +288,7 @@ parameter_types! {
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
 	pub CollectivesMaxProposalWeight: Weight = Perbill::from_percent(50) * RuntimeBlockWeights::get().max_block;
-	pub const SS58Prefix: u8 = 42;
+	pub const SS58Prefix: u16 = 12850;
 }
 
 /// The default types are being injected by [`derive_impl`](`frame_support::derive_impl`) from
@@ -318,7 +318,7 @@ impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	/// Weight information for the extrinsics of this pallet.
 	type SystemWeightInfo = weights::system::WeightInfo<Runtime>;
-	/// This is used as an identifier of the chain. 42 is the generic substrate prefix.
+	/// This is used as an identifier of the chain.
 	type SS58Prefix = SS58Prefix;
 	/// The maximum number of consumers allowed on a single account.
 	type MaxConsumers = frame_support::traits::ConstU32<16>;


### PR DESCRIPTION
## Description

This adds our own custom prefix `an` to ss58 encoded address.

The cargo patch directive will be removed once the prefix has been registered upstream.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Tests

After building the timechain node, you should be able to test the new network prefix via:

```
timechain-node key generate --network analog
```

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Inline comments have been added for each method
- [ ] I have made corresponding changes to the documentation
- [ ] Code changes introduces no new problems or warnings
- [ ] Test cases have been added 
- [ ] Dependent changes have been merged and published in downstream modules