### PR TITLE
runtime: retire incorrect DOLLAR constants

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -211,9 +211,6 @@ pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
 pub const HOURS: BlockNumber = MINUTES * 60;
 pub const DAYS: BlockNumber = HOURS * 24;
 
-pub const MILLICENTS: Balance = 1_000_000_000;
-pub const CENTS: Balance = 1_000 * MILLICENTS; // assume this is worth about a cent.
-pub const DOLLARS: Balance = 100 * CENTS;
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
 pub fn native_version() -> NativeVersion {
@@ -883,7 +880,7 @@ parameter_types! {
 	pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
 	pub const MaxApprovals: u32 = 100;
 	pub const ProposalBond: Permill = Permill::from_percent(5);
-	pub const ProposalBondMinimum: Balance = DOLLARS;
+	pub const ProposalBondMinimum: Balance = ANLOG;
 	pub const SpendPeriod: BlockNumber = DAYS;
 	pub const Burn: Permill = Permill::from_percent(50);
 	pub const MaxBalance: Balance = Balance::max_value();
@@ -935,7 +932,7 @@ impl pallet_members::Config for Runtime {
 	type WeightInfo = weights::members::WeightInfo<Runtime>;
 	type Elections = Elections;
 	type Networks = Networks;
-	type MinStake = ConstU128<{ 90_000 * DOLLARS }>;
+	type MinStake = ConstU128<{ 90_000 * ANLOG }>;
 	type HeartbeatTimeout = ConstU32<300>;
 }
 
@@ -967,9 +964,9 @@ impl pallet_tasks::Config for Runtime {
 	type Elections = Elections;
 	type Shards = Shards;
 	type Members = Members;
-	type BaseReadReward = ConstU128<{ 2 * DOLLARS }>;
-	type BaseWriteReward = ConstU128<{ 2 * DOLLARS }>;
-	type BaseSendMessageReward = ConstU128<{ 2 * DOLLARS }>;
+	type BaseReadReward = ConstU128<{ 2 * ANLOG }>;
+	type BaseWriteReward = ConstU128<{ 2 * ANLOG }>;
+	type BaseSendMessageReward = ConstU128<{ 2 * ANLOG }>;
 	type RewardDeclineRate = RewardDeclineRate;
 	type SignPhaseTimeout = ConstU32<10>;
 	type WritePhaseTimeout = ConstU32<10>;

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -41,7 +41,7 @@ fn new_test_ext() -> sp_io::TestExternalities {
 	let mut storage = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
 	let mut balances = vec![];
 	for i in 1..=(SHARD_SIZE * 3) {
-		balances.push((acc_pub(i.try_into().unwrap()).into(), 100_000 * DOLLARS));
+		balances.push((acc_pub(i.try_into().unwrap()).into(), 100_000 * ANLOG));
 	}
 	pallet_balances::GenesisConfig::<Runtime> { balances }
 		.assimilate_storage(&mut storage)
@@ -77,21 +77,21 @@ fn shard_not_stuck_in_committed_state() {
 			ETHEREUM,
 			pubkey_from_bytes(A),
 			get_peer_id(A),
-			90_000 * DOLLARS,
+			90_000 * ANLOG,
 		));
 		assert_ok!(Members::register_member(
 			RawOrigin::Signed(b.clone()).into(),
 			ETHEREUM,
 			pubkey_from_bytes(B),
 			get_peer_id(B),
-			90_000 * DOLLARS,
+			90_000 * ANLOG,
 		));
 		assert_ok!(Members::register_member(
 			RawOrigin::Signed(c.clone()).into(),
 			ETHEREUM,
 			pubkey_from_bytes(C),
 			get_peer_id(C),
-			90_000 * DOLLARS,
+			90_000 * ANLOG,
 		));
 		for (m, _) in ShardMembers::<Runtime>::iter_prefix(0) {
 			assert!(first_shard.contains(&m));
@@ -120,21 +120,21 @@ fn elections_chooses_top_members_by_stake() {
 			ETHEREUM,
 			pubkey_from_bytes(A),
 			get_peer_id(A),
-			90_000 * DOLLARS,
+			90_000 * ANLOG,
 		));
 		assert_ok!(Members::register_member(
 			RawOrigin::Signed(b.clone()).into(),
 			ETHEREUM,
 			pubkey_from_bytes(B),
 			get_peer_id(B),
-			90_000 * DOLLARS,
+			90_000 * ANLOG,
 		));
 		assert_ok!(Members::register_member(
 			RawOrigin::Signed(c.clone()).into(),
 			ETHEREUM,
 			pubkey_from_bytes(C),
 			get_peer_id(C),
-			90_000 * DOLLARS,
+			90_000 * ANLOG,
 		));
 		for (m, _) in ShardMembers::<Runtime>::iter_prefix(0) {
 			assert!(first_shard.contains(&m));
@@ -144,7 +144,7 @@ fn elections_chooses_top_members_by_stake() {
 			ETHEREUM,
 			pubkey_from_bytes(D),
 			get_peer_id(D),
-			90_001 * DOLLARS,
+			90_001 * ANLOG,
 		));
 		Elections::shard_offline(ETHEREUM, vec![a.clone(), b.clone(), c.clone()]);
 		for (m, _) in ShardMembers::<Runtime>::iter_prefix(1) {
@@ -166,21 +166,21 @@ fn write_phase_timeout_reassigns_task() {
 			ETHEREUM,
 			pubkey_from_bytes(A),
 			get_peer_id(A),
-			90_000 * DOLLARS,
+			90_000 * ANLOG,
 		));
 		assert_ok!(Members::register_member(
 			RawOrigin::Signed(b.clone()).into(),
 			ETHEREUM,
 			pubkey_from_bytes(B),
 			get_peer_id(B),
-			90_000 * DOLLARS,
+			90_000 * ANLOG,
 		));
 		assert_ok!(Members::register_member(
 			RawOrigin::Signed(c.clone()).into(),
 			ETHEREUM,
 			pubkey_from_bytes(C),
 			get_peer_id(C),
-			90_000 * DOLLARS,
+			90_000 * ANLOG,
 		));
 		Shards::create_shard(ETHEREUM, shard, 1);
 		<pallet_shards::ShardState<Runtime>>::insert(0, ShardStatus::Online);
@@ -226,21 +226,21 @@ fn register_unregister_preserves_task_migration() {
 			ETHEREUM,
 			pubkey_from_bytes(A),
 			get_peer_id(A),
-			90_000 * DOLLARS,
+			90_000 * ANLOG,
 		));
 		assert_ok!(Members::register_member(
 			RawOrigin::Signed(b.clone()).into(),
 			ETHEREUM,
 			pubkey_from_bytes(B),
 			get_peer_id(B),
-			90_000 * DOLLARS,
+			90_000 * ANLOG,
 		));
 		assert_ok!(Members::register_member(
 			RawOrigin::Signed(c.clone()).into(),
 			ETHEREUM,
 			pubkey_from_bytes(C),
 			get_peer_id(C),
-			90_000 * DOLLARS,
+			90_000 * ANLOG,
 		));
 		// verify shard 0 created for Network Ethereum
 		assert_eq!(Shards::shard_network(0), Some(ETHEREUM));
@@ -281,7 +281,7 @@ fn register_unregister_preserves_task_migration() {
 			ETHEREUM,
 			pubkey_from_bytes(D),
 			get_peer_id(D),
-			90_001 * DOLLARS,
+			90_001 * ANLOG,
 		));
 		// new member
 		assert_ok!(Members::register_member(
@@ -289,7 +289,7 @@ fn register_unregister_preserves_task_migration() {
 			ETHEREUM,
 			pubkey_from_bytes(E),
 			get_peer_id(E),
-			90_002 * DOLLARS,
+			90_002 * ANLOG,
 		));
 		// verify shard 1 created for Network Ethereum
 		assert_eq!(Shards::shard_network(1), Some(ETHEREUM));


### PR DESCRIPTION
## Description

While testing we came to realize that the `DOLLAR` constant does not actually use the same denomination as `ANLOG`.

This PR removes all use of the incorrect constants.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Inline comments have been added for each method
- [ ] I have made corresponding changes to the documentation
- [ ] Code changes introduces no new problems or warnings
- [ ] Test cases have been added 
- [ ] Dependent changes have been merged and published in downstream modules