### PR TITLE
Revert "Increase heartbeat timeout in runtime only (#787)"

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -933,7 +933,7 @@ impl pallet_members::Config for Runtime {
 	type Elections = Elections;
 	type Networks = Networks;
 	type MinStake = ConstU128<{ 90_000 * ANLOG }>;
-	type HeartbeatTimeout = ConstU32<300>;
+	type HeartbeatTimeout = ConstU32<50>;
 }
 
 impl pallet_elections::Config for Runtime {


### PR DESCRIPTION
This reverts commit 8e4d779964eee250c896c608b9f391c618cde485, reversing changes made to b63a9cea27a8c1c501db1c9bbdd12d9ba3a02fae.

Makes integration tests unbearably long