### PR TITLE
Add back check that TaskCreated event is emitted by create_task success

### DIFF
--- a/pallets/tasks/src/tests.rs
+++ b/pallets/tasks/src/tests.rs
@@ -120,6 +120,7 @@ fn test_create_task() {
 			mock_task(ETHEREUM)
 		));
 		System::assert_last_event(Event::<Test>::TaskAssigned(0, 0).into());
+		assert!(System::events().iter().any(|e| e.event == Event::<Test>::TaskCreated(0).into()));
 		assert_eq!(Tasks::get_shard_tasks(0), vec![TaskExecution::new(0, TaskPhase::Read)]);
 		let mut read_task_reward: u128 = <Test as crate::Config>::BaseReadReward::get();
 		read_task_reward =


### PR DESCRIPTION
Closes #803 to add back the check that `TaskCreated` event is emitted for successful calls to `create_task`.

The test assertion was removed in https://github.com/Analog-Labs/timechain/pull/802 and this is [the follow up](https://github.com/Analog-Labs/timechain/pull/802#discussion_r1541462044) to preserve the original check.