### PR TITLE
Assign tasks to partially offline shards

### DIFF
--- a/pallets/shards/src/lib.rs
+++ b/pallets/shards/src/lib.rs
@@ -316,7 +316,10 @@ pub mod pallet {
 
 	impl<T: Config> ShardsInterface for Pallet<T> {
 		fn is_shard_online(shard_id: ShardId) -> bool {
-			matches!(ShardState::<T>::get(shard_id), Some(ShardStatus::Online))
+			matches!(
+				ShardState::<T>::get(shard_id),
+				Some(ShardStatus::Online | ShardStatus::PartialOffline(_))
+			)
 		}
 
 		fn is_shard_member(member: &AccountId) -> bool {


### PR DESCRIPTION
Closes #852 by also returning true from `is_shard_online` if shard is partially offline