### PR TITLE
Fix cancel task to preserve shard assignment if it exists prior to cancellation

### DIFF
--- a/pallets/tasks/src/tests.rs
+++ b/pallets/tasks/src/tests.rs
@@ -1589,11 +1589,17 @@ fn cancel_task_sets_task_output_to_err() {
 			Tasks::shard_online(i, ETHEREUM);
 		}
 		for (task_id, _) in crate::Tasks::<Test>::iter() {
+			let shard_id = if let Some(s) = crate::TaskShard::<Test>::get(task_id) {
+				s
+			} else {
+				// 0 only if unassigned at cancellation
+				0
+			};
 			assert_ok!(Tasks::sudo_cancel_task(RawOrigin::Root.into(), task_id));
 			assert_eq!(
 				TaskOutput::<Test>::get(task_id),
 				Some(TaskResult {
-					shard_id: 0,
+					shard_id,
 					payload: Payload::Error("task cancelled by sudo".into()),
 					signature: [0u8; 64],
 				})


### PR DESCRIPTION
Made on top of #874 

The parent PR overwrites the shard field for TaskResult to 0 for all tasks cancelled by sudo.

This PR writes the shard assignment to `TaskResult.shard_id` with the expectation that `TaskResult.shard_id` is planned to be used to identify the task's shard assignment after its completion.