### PR TITLE
rust: pin stable version

### DIFF
--- a/.github/workflows/metadata.yaml
+++ b/.github/workflows/metadata.yaml
@@ -39,17 +39,8 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         submodules: recursive
-    - name: Install latest nightly
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy, rust-src
-
-    - name: Install cargo
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+    - name: Install rust toolchain
+      run : rustup show
     - name: Install subxt
       uses: actions-rs/cargo@v1
       with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
-components = [ "rustfmt", "clippy" ]
+channel = "1.78.0"
+components = [ "rust-src", "rust-analyzer" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
## Description

As discussed in DevOps sync, we want to pin the stable rust version we use, going forward.

- Pin stable to 1.78.0
- Remove redudant components already included by default profile (rustfmt and clippy)
- Include rust-src as required by wasm-builder
- Include rust-analyser, as it is generally useful and widely used
- Retire outdated `action-rs` action and use rustup instead 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Tests

Build the project with the new version and different targets.

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Inline comments have been added for each method
- [ ] I have made corresponding changes to the documentation
- [ ] Code changes introduces no new problems or warnings
- [ ] Test cases have been added 
- [ ] Dependent changes have been merged and published in downstream modules

(Note: Yes, the official way to install the current pinned rust version is `rustup show`.)