### PR TITLE
use correct latest version in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "chronicle"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -14947,7 +14947,7 @@ dependencies = [
 
 [[package]]
 name = "timechain-node"
-version = "0.0.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",

--- a/chronicle/Cargo.toml
+++ b/chronicle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chronicle"
-version = "0.1.0"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ description = "A blochain node using the proof of time consensus."
 edition = "2021"
 homepage = "https://analog.one/"
 repository = "https://github.com/analog-labs/testnet"
-version = "0.0.1"
+version = "0.5.0"
 
 [package.metadata.docs.rs]
 targets = [ "x86_64-unknown-linux-gnu" ]


### PR DESCRIPTION
## Description

We currently do not update our version number in cargo, this PR fixes this. In the future these versions should be bumped with each release, to ensure binaries report the correct version.