### PR TITLE
chain-sped: remove deprecated protocol id

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -338,7 +338,6 @@ impl GenesisKeysConfig {
 		let mut builder = ChainSpec::builder(wasm_binary, None)
 			.with_name(&name)
 			.with_id(id)
-			.with_protocol_id(id)
 			.with_chain_type(chain_type)
 			.with_properties(properties)
 			.with_genesis_config_patch(genesis_patch);

--- a/node/src/chains/testnet.raw.json
+++ b/node/src/chains/testnet.raw.json
@@ -12,7 +12,6 @@
       1
     ]
   ],
-  "protocolId": "anlogcc1",
   "properties": {
     "ss58Format": 12850,
     "tokenDecimals": 12,


### PR DESCRIPTION
## Description

Protocol ID is deprecated, this PR removes all use of it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Inline comments have been added for each method
- [ ] I have made corresponding changes to the documentation
- [x] Code changes introduces no new problems or warnings
- [ ] Test cases have been added 
- [ ] Dependent changes have been merged and published in downstream modules