### PR TITLE
Add submodule fetch in tester Docker build

### DIFF
--- a/.github/workflows/build-docker-tester.yaml
+++ b/.github/workflows/build-docker-tester.yaml
@@ -53,6 +53,8 @@ jobs:
     steps:
       - name: Fetch latest code
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Description

Summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes # (issue)

- fixes error when building tester to fetch submodules (specifically analog-gmp submodule) [build failed](https://github.com/Analog-Labs/timechain/actions/runs/9428409100)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Inline comments have been added for each method
- [ ] I have made corresponding changes to the documentation
- [ ] Code changes introduces no new problems or warnings
- [ ] Test cases have been added 
- [ ] Dependent changes have been merged and published in downstream modules