### PR TITLE
ci: ensure output folder exists

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -25,6 +25,7 @@ jobs:
         env:
           DOCS_HIDEOUT: an8ohgahmoot6ro8ieReib9micau0Oow
         run: |
+          mkdir target/docs
           cp -r target/doc target/docs/$DOCS_HIDEOUT
           cp docs/robots.txt target/docs/$DOCS_HIDEOUT
       - name: Deploy docs


### PR DESCRIPTION
## Description

Fixes deployment by ensuring folder exists before writing to it. :brain: :facepalm: 