### PR TITLE
ci: disable jekyll on docs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -26,6 +26,7 @@ jobs:
           DOCS_HIDEOUT: an8ohgahmoot6ro8ieReib9micau0Oow
         run: |
           mkdir target/docs
+          touch target/docs/.nojekyll
           cp -r target/doc target/docs/$DOCS_HIDEOUT
           cp docs/robots.txt target/docs/$DOCS_HIDEOUT
       - name: Deploy docs


### PR DESCRIPTION
## Description

This should disable jekyll turning our deployment into a render of the readme.