### PR TITLE
ci: install dependencies on hosted runners

### DIFF
--- a/.github/workflows/merge-pages-docs.yaml
+++ b/.github/workflows/merge-pages-docs.yaml
@@ -28,6 +28,8 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Build docs


### PR DESCRIPTION
## Description

Because the merge workflows are not running on the self-hosted runner, this change now install the missing protobuf dependencies as needed.