### PR TITLE
pallets: fix independet test build

### DIFF
--- a/pallets/elections/Cargo.toml
+++ b/pallets/elections/Cargo.toml
@@ -57,7 +57,8 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"frame-benchmarking?/std",
-	"time-primitives/std"
+	"time-primitives/std",
+	"pallet-balances/std"
 ]
 runtime-benchmarks = [
 	#"polkadot-sdk/runtime-benchmarks",

--- a/pallets/networks/Cargo.toml
+++ b/pallets/networks/Cargo.toml
@@ -38,7 +38,7 @@ sp-io = { git = "https://github.com/analog-labs/polkadot-sdk", tag = "v1.13.0-pa
 [features]
 default = [ "std" ]
 std = [
-    "scale-codec/std",
+	"scale-codec/std",
 	"scale-info/std",
 	#"polkadot-sdk/std",
 	"frame-support/std",
@@ -46,11 +46,12 @@ std = [
 	"sp-runtime/std",
 	"frame-benchmarking?/std",
 	"time-primitives/std",
+	"pallet-balances/std",
 ]
 runtime-benchmarks = [
 	#"polkadot-sdk/runtime-benchmarks",
 	"frame-benchmarking/runtime-benchmarks",
-    "pallet-balances/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
 ]
 try-runtime = [
 	#"polkadot-sdk/try-runtime"

--- a/pallets/shards/Cargo.toml
+++ b/pallets/shards/Cargo.toml
@@ -55,6 +55,7 @@ std = [
 	"frame-benchmarking?/std",
 	"schnorr-evm/std",
 	"time-primitives/std",
+	"pallet-balances/std"
 ]
 runtime-benchmarks = [
 	#"polkadot-sdk/runtime-benchmarks",

--- a/pallets/timegraph/Cargo.toml
+++ b/pallets/timegraph/Cargo.toml
@@ -40,6 +40,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"frame-benchmarking?/std",
+	"pallet-balances/std",
 ]
 runtime-benchmarks = [
 	#"polkadot-sdk/runtime-benchmarks",


### PR DESCRIPTION
## Description

If tests are build independently, `std` is not propagated properly and the build fails.