### PR TITLE
ci: disable testing of runtime-benchmarks feature

### DIFF
--- a/.github/workflows/pr-test-cargo.yaml
+++ b/.github/workflows/pr-test-cargo.yaml
@@ -33,11 +33,12 @@ jobs:
         uses: ./.github/actions/cargo-command
         with:
           command: test
-          args: --all-features --no-run
+          feature: try-runtime
+          args: --no-run
       - name: Run testsuite
         uses: ./.github/actions/cargo-command
         with:
           command: test
-          args: --all-features
+          feature: try-runtime
           cache: false
           annotate: false


### PR DESCRIPTION
## Description

The benchmarking tests are currently outdated, so the tests can not be build with `--all-features`. This reverts this change to only build the additional `try-runtime` for now.