### PR TITLE
fix(ci): runtime artifact name separation

### DIFF
--- a/.github/workflows/merge-srtool-runtime.yaml
+++ b/.github/workflows/merge-srtool-runtime.yaml
@@ -28,9 +28,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - chain: timechain
+          # Name denotes the artifact name in the workflow run
+          - name: testnet
+            chain: timechain
             features: default
-          - chain: timechain
+          - name: development
+            chain: timechain
             features: development
     steps:
       - name: Fetch latest code
@@ -53,7 +56,7 @@ jobs:
       - name: Upload timechain runtime artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: timechain-runtime-${{ matrix.features }}
+          name: ${{ matrix.name }}-runtime
           if-no-files-found: error
           path: |
             ${{ steps.srtool_build.outputs.wasm_compressed }}


### PR DESCRIPTION
## Description

Generate different name for different runtime artifact while building with srtool

Fixes

Broken srtool build when building multiple rntimes

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Inline comments have been added for each method
- [ ] I have made corresponding changes to the documentation
- [ ] Code changes introduces no new problems or warnings
- [ ] Test cases have been added 
- [ ] Dependent changes have been merged and published in downstream modules