### PR TITLE
fix(chain_spec): added bad block 1294505 of the old chain

### DIFF
--- a/node/src/chains/testnet.raw.json
+++ b/node/src/chains/testnet.raw.json
@@ -19,6 +19,9 @@
     "tokenSymbol": "TANLOG"
   },
   "codeSubstitutes": {},
+  "badBlocks": [
+    "0x4a352822c5de2b3519e27f2c56aa030512c1335e65e9ae420ba6754cfd9a39f9"
+  ],
   "genesis": {
     "raw": {
       "top": {


### PR DESCRIPTION
## Description

Friday, July 12th a missing migration caused the runtime upgrade to crash reading inconsistent state from the Session pallet. We reverted to 1294500 and started a new chain. This PR adds block 1294505 of the old chain to the bad blocks  section in the chain_spec for testnet.