### PR TITLE
Start work on frameless.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ resolver = "2"
 members = [
 	"chronicle",
 	"docs",
+	"frameless",
 	"node",
 	"pallets/elections",
 	"pallets/members",

--- a/frameless/Cargo.toml
+++ b/frameless/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "frameless"
+authors.workspace = true
+edition.workspace = true
+version.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+
+[dependencies]
+parity-scale-codec = { version = "3.6.12", default-features = false }
+sp-io = { version = "38.0.0", default-features = false }
+sp-std = { version = "14.0.0", default-features = false }
+time-primitives = { path = "../primitives", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+  "parity-scale-codec/std",
+  "sp-io/std",
+  "sp-std/std",
+  "time-primitives/std",
+]

--- a/frameless/src/lib.rs
+++ b/frameless/src/lib.rs
@@ -1,0 +1,61 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use crate::storage::{SpStorage, Storage, KV};
+use parity_scale_codec::{Decode, Encode};
+use time_primitives::{ChainName, ChainNetwork, NetworkId};
+
+mod storage;
+
+#[derive(Clone, Copy, Debug, Encode, Decode)]
+enum Prefix {
+	Networks,
+	NetworkId,
+}
+
+#[derive(Clone, Default)]
+pub struct Networks<S: KV>(Storage<S>);
+
+impl Networks<SpStorage> {
+	pub fn new() -> Self {
+		Self::default()
+	}
+}
+
+impl<S: KV> Networks<S> {
+	pub fn get(&self, id: NetworkId) -> Option<(ChainName, ChainNetwork)> {
+		self.0.get(&Prefix::Networks, &id)
+	}
+
+	pub fn insert(&self, name: ChainName, network: ChainNetwork) -> NetworkId {
+		for (id, (chain_name, chain_network)) in
+			self.0.iter::<_, NetworkId, (ChainName, ChainNetwork)>(&Prefix::Networks)
+		{
+			if chain_name == name && chain_network == network {
+				return id;
+			}
+		}
+		let id: NetworkId = self.0.get(&Prefix::NetworkId, b"").unwrap_or_default();
+		self.0.insert(&Prefix::Networks, &id, &(name, network));
+		self.0.insert(&Prefix::NetworkId, b"", &(id + 1));
+		id
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::storage::StdStorage;
+
+	#[test]
+	fn test_networks() {
+		let eth = ChainName::from("eth");
+		let sep = ChainNetwork::from("sepolia");
+		let networks = Networks::<StdStorage>::default();
+		assert!(networks.get(0).is_none());
+		networks.insert(eth.clone(), sep.clone());
+		assert_eq!(networks.get(0).unwrap(), (eth.clone(), sep.clone()));
+		networks.insert(eth.clone(), sep.clone());
+		assert!(networks.get(1).is_none());
+		assert_eq!(networks.get(0).unwrap(), (eth, sep));
+	}
+}

--- a/frameless/src/storage.rs
+++ b/frameless/src/storage.rs
@@ -1,0 +1,214 @@
+use core::marker::PhantomData;
+use parity_scale_codec::{Decode, Encode};
+#[cfg(not(feature = "std"))]
+use sp_std::vec::Vec;
+#[cfg(feature = "std")]
+use std::cell::RefCell;
+#[cfg(feature = "std")]
+use std::collections::BTreeMap;
+#[cfg(feature = "std")]
+use std::rc::Rc;
+
+pub trait KV: Default + Clone {
+	fn get(&self, key: &[u8]) -> Option<Vec<u8>>;
+
+	fn insert(&self, key: &[u8], value: &[u8]);
+
+	fn remove(&self, key: &[u8]);
+
+	fn next_key(&self, key: &[u8]) -> Option<Vec<u8>>;
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SpStorage;
+
+impl KV for SpStorage {
+	fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+		Some(sp_io::storage::get(&key)?.into())
+	}
+
+	fn insert(&self, key: &[u8], value: &[u8]) {
+		sp_io::storage::set(key, value);
+	}
+
+	fn remove(&self, key: &[u8]) {
+		sp_io::storage::clear(key);
+	}
+
+	fn next_key(&self, key: &[u8]) -> Option<Vec<u8>> {
+		sp_io::storage::next_key(key)
+	}
+}
+
+#[cfg(feature = "std")]
+#[derive(Clone, Debug, Default)]
+pub struct StdStorage(Rc<RefCell<BTreeMap<Vec<u8>, Vec<u8>>>>);
+
+#[cfg(feature = "std")]
+impl KV for StdStorage {
+	fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+		self.0.borrow().get(key).cloned()
+	}
+
+	fn insert(&self, key: &[u8], value: &[u8]) {
+		self.0.borrow_mut().insert(key.to_vec(), value.to_vec());
+	}
+
+	fn remove(&self, key: &[u8]) {
+		self.0.borrow_mut().remove(key);
+	}
+
+	fn next_key(&self, key: &[u8]) -> Option<Vec<u8>> {
+		self.0.borrow().keys().find(|k| k.as_slice() > key).cloned()
+	}
+}
+
+fn prefix_key<P: Encode, K: Encode>(prefix: &P, key: &K) -> Vec<u8> {
+	(prefix, key).encode()
+}
+
+#[derive(Clone, Default)]
+pub struct Storage<S: KV>(S);
+
+impl<S: KV> Storage<S> {
+	pub fn get<P: Encode, K: Encode, V: Decode>(&self, prefix: &P, key: &K) -> Option<V> {
+		let key = prefix_key(prefix, key);
+		let bytes = self.0.get(&key)?;
+		Decode::decode(&mut &bytes[..]).ok()
+	}
+
+	pub fn insert<P: Encode, K: Encode, V: Encode>(&self, prefix: &P, key: &K, value: &V) {
+		let key = prefix_key(prefix, key);
+		let value = value.encode();
+		self.0.insert(&key, &value);
+	}
+
+	pub fn remove<P: Encode, K: Encode>(&self, prefix: &P, key: &K) {
+		let key = prefix_key(prefix, key);
+		self.0.remove(&key);
+	}
+
+	fn raw_keys<P: Encode>(&self, prefix: &P) -> RawKeyIterator<S> {
+		RawKeyIterator::new(self.clone(), prefix.encode())
+	}
+
+	pub fn keys<P: Encode, K: Decode>(&self, prefix: &P) -> KeyIterator<S, K> {
+		KeyIterator::new(self.clone(), self.raw_keys(prefix))
+	}
+
+	pub fn values<P: Encode, V: Decode>(&self, prefix: &P) -> ValueIterator<S, V> {
+		ValueIterator::new(self.clone(), self.raw_keys(prefix))
+	}
+
+	pub fn iter<P: Encode, K: Decode, V: Decode>(&self, prefix: &P) -> StorageIterator<S, K, V> {
+		StorageIterator::new(self.clone(), self.raw_keys(prefix))
+	}
+}
+
+struct RawKeyIterator<S: KV> {
+	storage: Storage<S>,
+	prefix: Vec<u8>,
+	last_key: Vec<u8>,
+}
+
+impl<S: KV> RawKeyIterator<S> {
+	fn new(storage: Storage<S>, prefix: Vec<u8>) -> Self {
+		Self {
+			storage,
+			last_key: prefix.clone(),
+			prefix,
+		}
+	}
+}
+
+impl<S: KV> Iterator for RawKeyIterator<S> {
+	type Item = Vec<u8>;
+
+	fn next(&mut self) -> Option<Vec<u8>> {
+		let next_key = self.storage.0.next_key(&self.last_key)?;
+		if !next_key.starts_with(&self.prefix) {
+			return None;
+		}
+		self.last_key = next_key.clone();
+		Some(next_key)
+	}
+}
+
+pub struct KeyIterator<S: KV, K: Decode> {
+	_marker: PhantomData<K>,
+	storage: Storage<S>,
+	keys: RawKeyIterator<S>,
+}
+
+impl<S: KV, K: Decode> KeyIterator<S, K> {
+	fn new(storage: Storage<S>, keys: RawKeyIterator<S>) -> Self {
+		Self {
+			_marker: PhantomData,
+			storage,
+			keys,
+		}
+	}
+}
+
+impl<S: KV, K: Decode> Iterator for KeyIterator<S, K> {
+	type Item = K;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		let key = self.keys.next()?;
+		Decode::decode(&mut &key[..]).ok()
+	}
+}
+
+pub struct ValueIterator<S: KV, V: Decode> {
+	_marker: PhantomData<V>,
+	storage: Storage<S>,
+	keys: RawKeyIterator<S>,
+}
+
+impl<S: KV, V: Decode> ValueIterator<S, V> {
+	fn new(storage: Storage<S>, keys: RawKeyIterator<S>) -> Self {
+		Self {
+			_marker: PhantomData,
+			storage,
+			keys,
+		}
+	}
+}
+
+impl<S: KV, V: Decode> Iterator for ValueIterator<S, V> {
+	type Item = V;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		let key = self.keys.next()?;
+		let value = self.storage.0.get(&key)?;
+		Decode::decode(&mut &value[..]).ok()
+	}
+}
+
+pub struct StorageIterator<S: KV, K: Decode, V: Decode> {
+	_marker: PhantomData<(K, V)>,
+	storage: Storage<S>,
+	keys: RawKeyIterator<S>,
+}
+
+impl<S: KV, K: Decode, V: Decode> StorageIterator<S, K, V> {
+	fn new(storage: Storage<S>, keys: RawKeyIterator<S>) -> Self {
+		Self {
+			_marker: PhantomData,
+			storage,
+			keys,
+		}
+	}
+}
+
+impl<S: KV, K: Decode, V: Decode> Iterator for StorageIterator<S, K, V> {
+	type Item = (K, V);
+
+	fn next(&mut self) -> Option<Self::Item> {
+		let key = self.keys.next()?;
+		let value = self.storage.0.get(&key)?;
+		let key = Decode::decode(&mut &key[..]).ok()?;
+		let value = Decode::decode(&mut &value[..]).ok()?;
+		Some((key, value))
+	}
+}

--- a/pallets/networks/Cargo.toml
+++ b/pallets/networks/Cargo.toml
@@ -23,6 +23,7 @@ sp-runtime = { git = "https://github.com/analog-labs/polkadot-sdk", tag = "v1.13
 
 frame-benchmarking = { git = "https://github.com/analog-labs/polkadot-sdk", tag = "v1.13.0-patched2", default-features = false, optional = true }
 
+frameless = { path = "../../frameless", default-features = false }
 time-primitives = { path = "../../primitives", default-features = false }
 
 simple-mermaid.workspace = true
@@ -43,6 +44,7 @@ std = [
 	#"polkadot-sdk/std",
 	"frame-support/std",
 	"frame-system/std",
+	"frameless/std",
 	"sp-runtime/std",
 	"frame-benchmarking?/std",
 	"time-primitives/std",


### PR DESCRIPTION
Not exactly frameless, but we can create a single pallet that interfaces with the rest of the chain, keeping our core logic decoupled from substrate. Like decoupling the chronicle improved and fixed lots of issues, migrating the runtime logic might help us write cleaner, better tested and easier to maintain code.