### PR TITLE
polkadot-sdk: 1.14.0 -> 1.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aead"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,11 +215,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43b18702501396fa9bcdeecd533bc85fac75150d308fc0f6800a01e6234a003"
+checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "bytes",
 ]
 
@@ -229,7 +235,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
  "syn-solidity 0.4.2",
  "tiny-keccak",
 ]
@@ -243,11 +249,11 @@ dependencies = [
  "const-hex",
  "dunce",
  "heck 0.4.1",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
  "syn-solidity 0.6.4",
  "tiny-keccak",
 ]
@@ -390,7 +396,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -659,21 +665,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-secret-scalar"
-version = "0.0.2"
-source = "git+https://github.com/w3f/ring-vrf?rev=e9782f9#e9782f938629c90f3adb3fff2358bc8d1386af3e"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "ark-transcript",
- "digest 0.10.7",
- "getrandom_or_panic",
- "zeroize",
-]
-
-[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,19 +719,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-transcript"
-version = "0.0.2"
-source = "git+https://github.com/w3f/ring-vrf?rev=e9782f9#e9782f938629c90f3adb3fff2358bc8d1386af3e"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "digest 0.10.7",
- "rand_core 0.6.4",
- "sha3",
-]
-
-[[package]]
 name = "array-bytes"
 version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,9 +747,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii"
@@ -806,11 +784,11 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ad1373757efa0f70ec53939aabc7152e1591cb485208052993070ac8d2429d"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive 0.5.0",
+ "asn1-rs-derive 0.5.1",
  "asn1-rs-impl 0.2.0",
  "displaydoc",
  "nom 7.1.3",
@@ -834,13 +812,13 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
  "synstructure 0.13.1",
 ]
 
@@ -863,7 +841,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -874,8 +852,8 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "asset-test-utils"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -892,9 +870,8 @@ dependencies = [
  "parachains-common",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-builder",
@@ -904,8 +881,8 @@ dependencies = [
 
 [[package]]
 name = "assets-common"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -917,8 +894,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -990,7 +966,7 @@ checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
- "async-io 2.3.3",
+ "async-io 2.3.4",
  "async-lock 3.4.0",
  "blocking",
  "futures-lite 2.3.0",
@@ -1036,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
+checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
 dependencies = [
  "async-lock 3.4.0",
  "cfg-if",
@@ -1046,11 +1022,11 @@ dependencies = [
  "futures-io",
  "futures-lite 2.3.0",
  "parking",
- "polling 3.7.2",
+ "polling 3.7.3",
  "rustix 0.38.34",
  "slab",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1079,19 +1055,19 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
 dependencies = [
- "async-io 2.3.3",
+ "async-io 2.3.4",
  "blocking",
  "futures-lite 2.3.0",
 ]
 
 [[package]]
 name = "async-process"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7eda79bbd84e29c2b308d1dc099d7de8dcc7035e48f4bf5dc4a531a44ff5e2a"
+checksum = "a8a07789659a4d385b79b18b9127fc27e1a59e1e89117c78c5ea3b806f016374"
 dependencies = [
  "async-channel 2.3.1",
- "async-io 2.3.3",
+ "async-io 2.3.4",
  "async-lock 3.4.0",
  "async-signal",
  "async-task",
@@ -1101,16 +1077,16 @@ dependencies = [
  "futures-lite 2.3.0",
  "rustix 0.38.34",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb3634b73397aa844481f814fad23bbf07fdb0eabec10f2eb95e58944b1ec32"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
 dependencies = [
- "async-io 2.3.3",
+ "async-io 2.3.4",
  "async-lock 3.4.0",
  "atomic-waker",
  "cfg-if",
@@ -1119,7 +1095,7 @@ dependencies = [
  "rustix 0.38.34",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1167,7 +1143,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1197,7 +1173,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1253,7 +1229,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1283,32 +1259,9 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
- "object 0.36.2",
+ "miniz_oxide 0.7.4",
+ "object 0.36.3",
  "rustc-demangle",
-]
-
-[[package]]
-name = "bandersnatch_vrfs"
-version = "0.0.4"
-source = "git+https://github.com/w3f/ring-vrf?rev=e9782f9#e9782f938629c90f3adb3fff2358bc8d1386af3e"
-dependencies = [
- "ark-bls12-381",
- "ark-ec",
- "ark-ed-on-bls12-381-bandersnatch",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "dleq_vrf",
- "fflonk",
- "merlin",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "ring 0.1.0",
- "sha2 0.10.8",
- "sp-ark-bls12-381",
- "sp-ark-ed-on-bls12-381-bandersnatch",
- "zeroize",
 ]
 
 [[package]]
@@ -1376,8 +1329,8 @@ dependencies = [
 
 [[package]]
 name = "binary-merkle-tree"
-version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "15.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "hash-db",
  "log",
@@ -1410,7 +1363,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1524,7 +1477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "constant_time_eq 0.3.0",
 ]
 
@@ -1535,18 +1488,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94230421e395b9920d23df13ea5d77a20e1725331f90fbbf6df6040b33f756ae"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "constant_time_eq 0.3.0",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ec96fe9a81b5e365f9db71fe00edc4fe4ca2cc7dcb7861f0603012a7caa210"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "cc",
  "cfg-if",
  "constant_time_eq 0.3.0",
@@ -1612,8 +1565,8 @@ dependencies = [
 
 [[package]]
 name = "bp-asset-hub-rococo"
-version = "0.4.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.13.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-support",
@@ -1623,8 +1576,8 @@ dependencies = [
 
 [[package]]
 name = "bp-asset-hub-westend"
-version = "0.3.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.12.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-support",
@@ -1634,8 +1587,8 @@ dependencies = [
 
 [[package]]
 name = "bp-bridge-hub-cumulus"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -1644,69 +1597,69 @@ dependencies = [
  "frame-system",
  "polkadot-primitives",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-bridge-hub-kusama"
-version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-bridge-hub-polkadot"
-version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-bridge-hub-rococo"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-bridge-hub-westend"
-version = "0.3.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.13.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-header-chain"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1715,28 +1668,28 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-grandpa",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-kusama"
-version = "0.5.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.15.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-messages"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1744,14 +1697,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-parachains"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1760,28 +1713,28 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-polkadot"
-version = "0.5.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.15.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-polkadot-bulletin"
-version = "0.4.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.14.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1792,14 +1745,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-polkadot-core"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1809,42 +1762,42 @@ dependencies = [
  "parity-util-mem",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-relayers"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-messages",
  "bp-runtime",
  "frame-support",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-rococo"
-version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-runtime"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1855,19 +1808,19 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-trie 37.0.0",
  "trie-db 0.29.1",
 ]
 
 [[package]]
 name = "bp-test-utils"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1876,50 +1829,50 @@ dependencies = [
  "ed25519-dalek",
  "finality-grandpa",
  "parity-scale-codec",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-grandpa",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "bp-westend"
-version = "0.3.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.13.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub"
-version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.3.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.14.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "bridge-hub-common"
-version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1927,16 +1880,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "snowbridge-core",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
  "staging-xcm",
 ]
 
 [[package]]
 name = "bridge-hub-test-utils"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -1962,12 +1914,11 @@ dependencies = [
  "parachains-common",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-keyring 31.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-keyring 39.0.0",
+ "sp-runtime 39.0.0",
+ "sp-tracing 17.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -1975,8 +1926,8 @@ dependencies = [
 
 [[package]]
 name = "bridge-runtime-common"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1988,7 +1939,6 @@ dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-support",
  "frame-system",
- "hash-db",
  "log",
  "pallet-bridge-grandpa",
  "pallet-bridge-messages",
@@ -1998,12 +1948,10 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-trie 37.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "tuplex",
@@ -2059,9 +2007,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
 
 [[package]]
 name = "byteorder"
@@ -2071,9 +2019,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 dependencies = [
  "serde",
 ]
@@ -2111,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -2143,12 +2091,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -2341,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.11"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2351,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.11"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2364,23 +2313,23 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.11"
+version = "4.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ae69fbb0833c6fcd5a8d4b8609f108c7ad95fc11e248d853ff2c42a90df26a"
+checksum = "9340e41703683548f486fdfdce615b0520dd220d18b1d4ce5abbc87d461c221b"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.11"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2441,22 +2390,6 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "unicode-width",
-]
-
-[[package]]
-name = "common"
-version = "0.1.0"
-source = "git+https://github.com/w3f/ring-proof#665f5f51af5734c7b6d90b985dd6861d4c5b4752"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "fflonk",
- "getrandom_or_panic",
- "merlin",
- "rand_chacha 0.3.1",
 ]
 
 [[package]]
@@ -2550,26 +2483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
-name = "const_format"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2631,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core2"
@@ -2655,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -2792,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
 name = "crossbeam-deque"
@@ -2941,8 +2854,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2951,16 +2864,15 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-aura",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "cumulus-pallet-dmp-queue"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -2969,16 +2881,15 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2997,14 +2908,14 @@ dependencies = [
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
  "sp-inherents",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-trie 37.0.0",
  "sp-version",
  "staging-xcm",
  "staging-xcm-builder",
@@ -3014,32 +2925,31 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
-version = "9.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "cumulus-pallet-solo-to-para"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3048,30 +2958,28 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -3085,10 +2993,9 @@ dependencies = [
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -3096,8 +3003,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-ping"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -3105,29 +3012,27 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-primitives-aura"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.15.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-primitives",
  "sp-api",
  "sp-consensus-aura",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.15.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3135,43 +3040,41 @@ dependencies = [
  "polkadot-primitives",
  "scale-info",
  "sp-api",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-runtime 39.0.0",
+ "sp-trie 37.0.0",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.15.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.10.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-externalities 0.29.0",
+ "sp-runtime-interface 28.0.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
-version = "1.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "7.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3181,27 +3084,23 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-timestamp"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.15.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-primitives-core",
- "futures",
- "parity-scale-codec",
  "sp-inherents",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3210,9 +3109,8 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -3220,16 +3118,15 @@ dependencies = [
 
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.15.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
@@ -3269,14 +3166,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "cxx"
-version = "1.0.124"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273dcfd3acd4e1e276af13ed2a43eea7001318823e7a726a6b3ed39b4acc0b82"
+checksum = "3c4eae4b7fc8dcb0032eb3b1beee46b38d371cdeaf2d0c64b9944f6f69ad7755"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -3286,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.124"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b2766fbd92be34e9ed143898fce6c572dc009de39506ed6903e5a05b68914e"
+checksum = "6c822bf7fb755d97328d6c337120b6f843678178751cba33c9da25cf522272e0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -3296,24 +3193,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.124"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839fcd5e43464614ffaa989eaf1c139ef1f0c51672a1ed08023307fa1b909ccd"
+checksum = "719d6197dc016c88744aff3c0d0340a01ecce12e8939fc282e7c8f583ee64bc6"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.124"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2c1c1776b986979be68bb2285da855f8d8a35851a769fca8740df7c3d07877"
+checksum = "35de3b547387863c8f82013c4f79f1c2162edee956383e4089e1d04c18c4f16c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3361,7 +3258,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3383,7 +3280,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3477,7 +3374,7 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs 0.6.1",
+ "asn1-rs 0.6.2",
  "displaydoc",
  "nom 7.1.3",
  "num-bigint",
@@ -3493,7 +3390,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3536,7 +3433,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3547,7 +3444,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3560,7 +3457,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3580,8 +3477,18 @@ checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
  "unicode-xid",
+]
+
+[[package]]
+name = "diatomic-waker"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce3b3a843da2390ad9693fc640ed7081015fd73f280cab2b2081404a8ecceb99"
+dependencies = [
+ "loom",
+ "waker-fn",
 ]
 
 [[package]]
@@ -3695,23 +3602,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "dleq_vrf"
-version = "0.0.2"
-source = "git+https://github.com/w3f/ring-vrf?rev=e9782f9#e9782f938629c90f3adb3fff2358bc8d1386af3e"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-scale",
- "ark-secret-scalar",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "ark-transcript",
- "arrayvec 0.7.4",
- "zeroize",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3746,9 +3637,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.72",
+ "syn 2.0.75",
  "termcolor",
- "toml 0.8.16",
+ "toml 0.8.19",
  "walkdir",
 ]
 
@@ -3793,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clonable"
@@ -3928,6 +3819,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "ena"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3972,7 +3869,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3992,18 +3889,18 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "enumn"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4143,7 +4040,7 @@ version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "bytes",
  "chrono",
  "const-hex",
@@ -4255,7 +4152,7 @@ dependencies = [
  "prettyplease 0.2.20",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4291,7 +4188,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "auto_impl",
  "bytes",
 ]
@@ -4313,11 +4210,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb42427514b063d97ce21d5199f36c0c307d981434a6be32582bc79fe5bd2303"
 dependencies = [
  "expander",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4338,19 +4235,6 @@ checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core 0.6.4",
  "subtle 2.6.1",
-]
-
-[[package]]
-name = "fflonk"
-version = "0.1.0"
-source = "git+https://github.com/w3f/fflonk#1e854f35e9a65d08b11a86291405cdc95baa0a35"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "merlin",
 ]
 
 [[package]]
@@ -4381,14 +4265,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+checksum = "bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
- "windows-sys 0.52.0",
+ "libredox",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4437,12 +4321,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -4498,8 +4382,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-tree"
-version = "12.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad4cc2314d3be8b49c555f6a7e550f5559e73ffd6ef9690ffbd9a706774452e0"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4507,8 +4392,7 @@ dependencies = [
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad4cc2314d3be8b49c555f6a7e550f5559e73ffd6ef9690ffbd9a706774452e0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4550,8 +4434,8 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4563,20 +4447,19 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-runtime-interface 24.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-storage 19.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-application-crypto 38.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-runtime-interface 28.0.0",
+ "sp-storage 21.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "32.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "42.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -4607,69 +4490,67 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-database",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-externalities 0.29.0",
  "sp-genesis-builder",
  "sp-inherents",
- "sp-io 30.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
- "sp-storage 19.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
- "sp-wasm-interface 20.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-storage 21.0.0",
+ "sp-trie 37.0.0",
+ "sp-wasm-interface 21.0.0",
  "thiserror",
  "thousands",
 ]
 
 [[package]]
 name = "frame-benchmarking-pallet-pov"
-version = "18.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "27.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "frame-election-provider-solution-type"
-version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "14.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
  "sp-npos-elections",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "frame-executive"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4678,11 +4559,10 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
@@ -4710,8 +4590,8 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata-hash-extension"
-version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.5.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "docify",
@@ -4720,13 +4600,13 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "frame-support"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4746,28 +4626,28 @@ dependencies = [
  "serde_json",
  "smallvec",
  "sp-api",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
  "sp-crypto-hashing-proc-macro",
- "sp-debug-derive 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "sp-genesis-builder",
  "sp-inherents",
- "sp-io 30.0.0",
+ "sp-io 38.0.0",
  "sp-metadata-ir",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-staking",
- "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-weights 27.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-tracing 17.0.0",
+ "sp-weights 31.0.0",
  "static_assertions",
  "tt-call",
 ]
 
 [[package]]
 name = "frame-support-procedural"
-version = "23.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "30.0.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4779,36 +4659,36 @@ dependencies = [
  "proc-macro-warning 1.0.2",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "syn 2.0.72",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "10.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "13.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "11.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "12.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "frame-system"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.1.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4817,33 +4697,32 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "sp-version",
- "sp-weights 27.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4852,14 +4731,13 @@ dependencies = [
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.34.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.43.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -4983,12 +4861,12 @@ dependencies = [
 
 [[package]]
 name = "futures-buffered"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dcae03ee5afa5ea17b1aebc793806b8ddfc6dc500e0b8e8e1eb30b9dad22c0"
+checksum = "91fa130f3777d0d4b0993653c20bc433026d3290627693c4ed1b18dd237357ab"
 dependencies = [
+ "diatomic-waker",
  "futures-core",
- "futures-util",
  "pin-project-lite",
 ]
 
@@ -5077,7 +4955,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -5137,8 +5015,8 @@ dependencies = [
 
 [[package]]
 name = "generate-bags"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "chrono",
  "frame-election-provider-support",
@@ -5147,6 +5025,19 @@ dependencies = [
  "num-format",
  "pallet-staking",
  "sp-staking",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "979f00864edc7516466d6b3157706e06c032f22715700ddd878228a91d02bc56"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -5330,7 +5221,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5339,9 +5230,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5349,7 +5240,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5785,7 +5676,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -5834,9 +5725,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5928,7 +5819,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b0422c86d7ce0e97169cc42e04ae643caf278874a7a3c87b8150a220dc7e1e"
 dependencies = [
- "async-io 2.3.3",
+ "async-io 2.3.4",
  "core-foundation",
  "fnv",
  "futures",
@@ -6041,9 +5932,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -6120,7 +6011,7 @@ dependencies = [
  "socket2 0.5.7",
  "widestring",
  "windows-sys 0.48.0",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
@@ -6163,7 +6054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbba31f40a650f58fa28dd585a8ca76d8ae3ba63aacab4c8269004a0c803930"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "cc",
  "cfg-if",
  "constant_time_eq 0.3.0",
@@ -6181,7 +6072,7 @@ dependencies = [
  "hyper-util",
  "once_cell",
  "prometheus-client 0.22.3",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde",
  "struct_iterable",
  "time 0.3.36",
@@ -6237,7 +6128,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rcgen 0.12.1",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "ring 0.17.8",
  "rtnetlink 0.13.1",
  "rustls 0.21.12",
@@ -6314,11 +6205,11 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -6402,9 +6293,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -6438,15 +6329,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.0"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e419d6c39cb9632288c592a06d7d0a96740021b0bff812e211ace754b0fe8c9a"
+checksum = "5ec465b607a36dc5dd45d48b7689bc83f679f66a3ac6b6b21cc787a11e0f8685"
 dependencies = [
- "jsonrpsee-client-transport 0.24.0",
- "jsonrpsee-core 0.24.0",
- "jsonrpsee-http-client 0.24.0",
- "jsonrpsee-types 0.24.0",
- "jsonrpsee-ws-client 0.24.0",
+ "jsonrpsee-client-transport 0.24.3",
+ "jsonrpsee-core 0.24.3",
+ "jsonrpsee-http-client 0.24.3",
+ "jsonrpsee-types 0.24.3",
+ "jsonrpsee-ws-client 0.24.3",
 ]
 
 [[package]]
@@ -6459,7 +6350,7 @@ dependencies = [
  "http 0.2.12",
  "jsonrpsee-core 0.22.5",
  "pin-project",
- "rustls-native-certs 0.7.1",
+ "rustls-native-certs 0.7.2",
  "rustls-pki-types",
  "soketto 0.7.1",
  "thiserror",
@@ -6495,14 +6386,14 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.24.0"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b6dc3b1e2da087969e69a095e7d6127966c8c194490b311017bb2053a7d5a1"
+checksum = "90f0977f9c15694371b8024c35ab58ca043dbbf4b51ccb03db8858a021241df1"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
  "http 1.1.0",
- "jsonrpsee-core 0.24.0",
+ "jsonrpsee-core 0.24.3",
  "pin-project",
  "rustls 0.23.12",
  "rustls-pki-types",
@@ -6569,9 +6460,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.0"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06b8be79a3bdd7d87c1d95c0e939052b7f64fffce7b9436986e43e92f20a978"
+checksum = "e942c55635fbf5dc421938b8558a8141c7e773720640f4f1dbe1f4164ca4e221"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6580,7 +6471,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "jsonrpsee-types 0.24.0",
+ "jsonrpsee-types 0.24.3",
  "pin-project",
  "rustc-hash 2.0.0",
  "serde",
@@ -6613,9 +6504,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.24.0"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dc99c70619e252e6adc5e95144323505a69a1742771de5b3f2071e1595b363"
+checksum = "e33774602df12b68a2310b38a535733c477ca4a498751739f89fe8dbbb62ec4c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6623,8 +6514,8 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
  "hyper-util",
- "jsonrpsee-core 0.24.0",
- "jsonrpsee-types 0.24.0",
+ "jsonrpsee-core 0.24.3",
+ "jsonrpsee-types 0.24.3",
  "rustls 0.23.12",
  "rustls-platform-verifier",
  "serde",
@@ -6646,7 +6537,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6705,9 +6596,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.0"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0feba38a9878d70ccccd2f54b534b15e861d6caa7911d59abfd3e0d8b4de091f"
+checksum = "23b67d6e008164f027afbc2e7bb79662650158d26df200040282d2aa1cbb093b"
 dependencies = [
  "http 1.1.0",
  "serde",
@@ -6730,14 +6621,14 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.24.0"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82b1c7fc629c345581d89ad802d53dc11d18df11d4d94d2c95da6e70f8520d3"
+checksum = "992bf67d1132f88edf4a4f8cff474cf01abb2be203004a2b8e11c2b20795b99e"
 dependencies = [
  "http 1.1.0",
- "jsonrpsee-client-transport 0.24.0",
- "jsonrpsee-core 0.24.0",
- "jsonrpsee-types 0.24.0",
+ "jsonrpsee-client-transport 0.24.3",
+ "jsonrpsee-core 0.24.3",
+ "jsonrpsee-types 0.24.3",
  "url",
 ]
 
@@ -6767,9 +6658,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a3633291834c4fbebf8673acbc1b04ec9d151418ff9b8e26dcd79129928758"
+checksum = "422fbc7ff2f2f5bdffeb07718e5a5324dca72b0c9293d50df4026652385e3314"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -6883,9 +6774,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"
@@ -7023,7 +6914,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "lru 0.12.3",
+ "lru 0.12.4",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
@@ -7055,7 +6946,7 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ea178dabba6dde6ffc260a8e0452ccdc8f79becf544946692fff9d412fc29d"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "asynchronous-codec",
  "bytes",
  "either",
@@ -7234,7 +7125,7 @@ dependencies = [
  "proc-macro-warning 0.4.2",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -7345,6 +7236,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
+ "redox_syscall 0.5.3",
 ]
 
 [[package]]
@@ -7412,9 +7304,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.18"
+version = "1.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
 dependencies = [
  "cc",
  "pkg-config",
@@ -7498,7 +7390,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "hex-literal",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "libc",
  "mockall 0.12.1",
  "multiaddr 0.17.1",
@@ -7574,6 +7466,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
 name = "lru"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7584,9 +7489,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -7638,7 +7543,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -7652,7 +7557,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -7663,7 +7568,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -7674,7 +7579,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -7732,9 +7637,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -7882,10 +7787,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.0.1"
+name = "miniz_oxide"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
@@ -7900,7 +7814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daa3eb39495d8e2e2947a1d862852c90cc6a4a8845f8b41c8829cb9fcc047f4a"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "bitflags 1.3.2",
  "blake2 0.10.6",
  "c2-chacha",
@@ -7920,8 +7834,8 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "29.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "39.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "futures",
  "log",
@@ -7932,24 +7846,24 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "mmr-rpc"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "jsonrpsee 0.23.2",
  "parity-scale-codec",
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -8003,7 +7917,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -8169,7 +8083,7 @@ checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -8499,7 +8413,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -8508,7 +8422,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "itoa",
 ]
 
@@ -8565,23 +8479,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -8607,9 +8521,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.2"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
@@ -8629,7 +8543,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c958dd45046245b9c3c2547369bb634eb461670b2e7e0de552905801a648d1d"
 dependencies = [
- "asn1-rs 0.6.1",
+ "asn1-rs 0.6.2",
 ]
 
 [[package]]
@@ -8656,7 +8570,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "auto_impl",
  "bytes",
  "ethereum-types",
@@ -8698,7 +8612,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -8737,9 +8651,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestra"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92829eef0328a3d1cd22a02c0e51deb92a5362df3e7d21a4e9bdc38934694e66"
+checksum = "41f6bbacc8c189a3f2e45e0fd0436e5d97f194db888e721bdbc3973e7dbed4c2"
 dependencies = [
  "async-trait",
  "dyn-clonable",
@@ -8754,12 +8668,12 @@ dependencies = [
 
 [[package]]
 name = "orchestra-proc-macro"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1344346d5af32c95bbddea91b18a88cc83eac394192d20ef2fc4c40a74332355"
+checksum = "f7b1d40dd8f367db3c65bec8d3dd47d4a604ee8874480738f93191bddab4e0e0"
 dependencies = [
  "expander",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "itertools 0.11.0",
  "petgraph",
  "proc-macro-crate 3.1.0",
@@ -8779,12 +8693,12 @@ dependencies = [
 
 [[package]]
 name = "os_pipe"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d73ba8daf8fac13b0501d1abeddcfe21ba7401ada61a819144b6c2a4f32209"
+checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8833,8 +8747,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-alliance"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "frame-benchmarking",
@@ -8845,17 +8759,16 @@ dependencies = [
  "pallet-identity",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-asset-conversion"
-version = "10.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "19.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8864,17 +8777,16 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-asset-conversion-ops"
-version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.5.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8883,17 +8795,16 @@ dependencies = [
  "pallet-asset-conversion",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
-version = "10.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "19.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8901,29 +8812,27 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-asset-rate"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8932,16 +8841,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-assets"
-version = "29.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "39.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8950,15 +8858,14 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-assets-freezer"
-version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.4.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8967,28 +8874,27 @@ dependencies = [
  "pallet-assets",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-atomic-swap"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-aura"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8996,46 +8902,43 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-aura",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-authority-discovery",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-authorship"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-babe"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9046,20 +8949,19 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-babe",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-bags-list"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9071,17 +8973,16 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
 name = "pallet-balances"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9090,14 +8991,13 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-beefy"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9108,16 +9008,15 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -9132,17 +9031,16 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-consensus-beefy",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
 ]
 
 [[package]]
 name = "pallet-bounties"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9151,21 +9049,19 @@ dependencies = [
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-bridge-grandpa"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
  "bp-test-utils",
- "finality-grandpa",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -9173,33 +9069,33 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-consensus-grandpa",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "pallet-bridge-messages"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
+ "bp-header-chain",
  "bp-messages",
  "bp-runtime",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
- "num-traits",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "pallet-bridge-parachains"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -9212,15 +9108,14 @@ dependencies = [
  "pallet-bridge-grandpa",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "pallet-bridge-relayers"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-messages",
  "bp-relayers",
@@ -9232,15 +9127,15 @@ dependencies = [
  "pallet-bridge-messages",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "pallet-broker"
-version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9250,16 +9145,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-child-bounties"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9269,16 +9163,15 @@ dependencies = [
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-collator-selection"
-version = "9.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9290,15 +9183,14 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-collective"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9306,31 +9198,29 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-collective-content"
-version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.15.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-contracts"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -9350,10 +9240,10 @@ dependencies = [
  "serde",
  "smallvec",
  "sp-api",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "staging-xcm",
  "staging-xcm-builder",
  "wasm-instrument",
@@ -9362,8 +9252,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-mock-network"
-version = "3.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "13.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9384,12 +9274,11 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-api",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.0",
+ "sp-tracing 17.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -9398,18 +9287,18 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-proc-macro"
-version = "18.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "23.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "pallet-contracts-uapi"
-version = "5.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "12.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -9420,8 +9309,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9430,15 +9319,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-core-fellowship"
-version = "12.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "21.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9447,31 +9335,29 @@ dependencies = [
  "pallet-ranked-collective",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-delegated-staking"
-version = "1.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "4.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-democracy"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9480,16 +9366,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-dev-mode"
-version = "10.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "19.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9497,15 +9382,14 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9516,27 +9400,25 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
  "strum 0.26.3",
 ]
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-system",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -9557,8 +9439,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "29.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9566,18 +9448,17 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9587,16 +9468,15 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-glutton"
-version = "14.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "23.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -9605,11 +9485,10 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-inherents",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -9624,8 +9503,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9635,20 +9514,19 @@ dependencies = [
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-grandpa",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-identity"
-version = "29.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9657,15 +9535,14 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-im-online"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9674,57 +9551,53 @@ dependencies = [
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
+ "sp-application-crypto 38.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-indices"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-keyring 31.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-keyring 39.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
-version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "25.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "safe-mix",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-lottery"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -9743,8 +9616,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-membership"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9752,16 +9625,15 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-message-queue"
-version = "31.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "40.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9770,18 +9642,17 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-weights 27.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
 name = "pallet-migrations"
-version = "1.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "7.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9791,15 +9662,14 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-mixnet"
-version = "0.4.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.13.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9808,18 +9678,17 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-application-crypto 30.0.0",
- "sp-arithmetic 23.0.0",
- "sp-io 30.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-io 38.0.0",
  "sp-mixnet",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-mmr"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9827,17 +9696,16 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-multisig"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9845,9 +9713,8 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -9863,8 +9730,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-fractionalization"
-version = "10.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "20.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9874,14 +9741,13 @@ dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-nfts"
-version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "31.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9890,59 +9756,55 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-nfts-runtime-api"
-version = "14.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "23.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-nis"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-node-authorization"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "25.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9950,18 +9812,17 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "35.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9973,27 +9834,25 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-runtime-interface 24.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
+ "sp-runtime-interface 28.0.0",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "23.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "32.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-offences"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10002,15 +9861,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10026,15 +9884,14 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-paged-list"
-version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.15.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10042,17 +9899,16 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
  "sp-metadata-ir",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-parameters"
-version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.8.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10062,15 +9918,14 @@ dependencies = [
  "paste",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-preimage"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10078,31 +9933,29 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-proxy"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10111,32 +9964,30 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-recovery"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-referenda"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10146,16 +9997,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic 23.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-remark"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10163,16 +10013,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-root-offences"
-version = "25.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10180,29 +10029,28 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-root-testing"
-version = "4.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "13.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-safe-mode"
-version = "9.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10213,15 +10061,14 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-salary"
-version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "22.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10230,17 +10077,16 @@ dependencies = [
  "pallet-ranked-collective",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-scheduler"
-version = "29.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10249,30 +10095,28 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-weights 27.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
 name = "pallet-scored-pool"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-session"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10281,20 +10125,19 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-session",
  "sp-staking",
- "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10303,9 +10146,8 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "rand 0.8.5",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
@@ -10324,21 +10166,20 @@ dependencies = [
 
 [[package]]
 name = "pallet-skip-feeless-payment"
-version = "3.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "12.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-society"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10347,16 +10188,15 @@ dependencies = [
  "parity-scale-codec",
  "rand_chacha 0.3.1",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-staking"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10369,37 +10209,36 @@ dependencies = [
  "rand_chacha 0.3.1",
  "scale-info",
  "serde",
- "sp-application-crypto 30.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
+ "sp-application-crypto 38.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-staking-reward-curve"
-version = "11.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "12.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "pallet-staking-reward-fn"
-version = "19.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "22.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "log",
- "sp-arithmetic 23.0.0",
+ "sp-arithmetic 26.0.0",
 ]
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "14.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "22.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10408,8 +10247,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "29.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "39.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10417,16 +10256,15 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-statement"
-version = "10.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "19.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10434,17 +10272,16 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-statement-store",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "pallet-sudo"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10452,9 +10289,8 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -10485,8 +10321,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10496,17 +10332,16 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-inherents",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-storage 19.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-storage 21.0.0",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-tips"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10516,60 +10351,58 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "30.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "40.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "jsonrpsee 0.23.2",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
+ "sp-runtime 39.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
+ "sp-runtime 39.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
 name = "pallet-transaction-storage"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "frame-benchmarking",
@@ -10581,16 +10414,15 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-inherents",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-transaction-storage-proof",
 ]
 
 [[package]]
 name = "pallet-treasury"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10601,15 +10433,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-tx-pause"
-version = "9.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10620,14 +10451,13 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-uniques"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10635,30 +10465,28 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-utility"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-vesting"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10666,14 +10494,13 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-whitelist"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10681,14 +10508,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-xcm"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -10699,10 +10525,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -10711,8 +10536,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10720,9 +10545,8 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -10730,8 +10554,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub"
-version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.12.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -10743,9 +10567,9 @@ dependencies = [
  "pallet-bridge-messages",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -10753,8 +10577,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
-version = "0.5.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.14.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -10763,9 +10587,9 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "staging-xcm",
  "staging-xcm-builder",
 ]
@@ -10783,8 +10607,8 @@ dependencies = [
 
 [[package]]
 name = "parachains-common"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -10802,10 +10626,9 @@ dependencies = [
  "polkadot-primitives",
  "scale-info",
  "sp-consensus-aura",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
@@ -10814,8 +10637,8 @@ dependencies = [
 
 [[package]]
 name = "parachains-runtimes-test-utils"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -10832,11 +10655,10 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "sp-consensus-aura",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-tracing 17.0.0",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
@@ -10889,7 +10711,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "bitvec",
  "byte-slice-cast",
  "bytes",
@@ -11148,7 +10970,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -11169,7 +10991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
 ]
 
 [[package]]
@@ -11202,7 +11024,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -11240,7 +11062,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -11257,9 +11079,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
  "fastrand 2.1.0",
@@ -11268,9 +11090,9 @@ dependencies = [
 
 [[package]]
 name = "pkarr"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8ffdac8b4b7ea5240c46b28f88de799e0efaa2b93ccb08eaae6e50835dfe137"
+checksum = "7945a08031b7e14de57e8385cea3bcc7e10a88701595dc11d82551ba07bae13e"
 dependencies = [
  "bytes",
  "document-features",
@@ -11278,7 +11100,7 @@ dependencies = [
  "flume",
  "futures",
  "js-sys",
- "lru 0.12.3",
+ "lru 0.12.4",
  "self_cell",
  "simple-dns 0.6.2",
  "thiserror",
@@ -11335,7 +11157,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -11371,8 +11193,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cfg-if",
  "frame-benchmarking-cli",
@@ -11385,45 +11207,44 @@ dependencies = [
  "sc-service",
  "sc-storage-monitor",
  "sc-sysinfo",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-keyring 31.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-keyring 39.0.0",
  "sp-maybe-compressed-blob",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "substrate-build-script-utils",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "15.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "15.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-primitives",
  "reed-solomon-novelpoly",
- "sp-core 28.0.0",
- "sp-trie 29.0.0",
+ "sp-core 34.0.0",
+ "sp-trie 37.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "futures",
@@ -11439,8 +11260,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "lazy_static",
  "log",
@@ -11451,15 +11272,15 @@ dependencies = [
  "polkadot-primitives",
  "sc-network",
  "sc-network-types",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -11477,8 +11298,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -11495,7 +11316,7 @@ dependencies = [
  "sc-authority-discovery",
  "sc-network",
  "sc-network-types",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "strum 0.26.3",
  "thiserror",
  "tracing-gum",
@@ -11503,8 +11324,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "15.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -11514,20 +11335,20 @@ dependencies = [
  "polkadot-primitives",
  "schnorrkel",
  "serde",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-babe",
- "sp-core 28.0.0",
- "sp-keystore 0.34.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
  "sp-maybe-compressed-blob",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "thiserror",
  "zstd 0.12.4",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -11536,8 +11357,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.1.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -11559,15 +11380,15 @@ dependencies = [
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-consensus-babe",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.1.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "derive_more 0.99.18",
@@ -11593,17 +11414,17 @@ dependencies = [
  "rand 0.8.5",
  "sc-client-api",
  "schnellru",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-keystore 0.34.0",
+ "sp-application-crypto 38.0.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-overseer"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "futures",
@@ -11617,15 +11438,15 @@ dependencies = [
  "polkadot-primitives",
  "sc-client-api",
  "sp-api",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "tikv-jemalloc-ctl",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-parachain-primitives"
-version = "6.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "14.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.18",
@@ -11633,16 +11454,15 @@ dependencies = [
  "polkadot-core-primitives",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-weights 27.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-weights 31.0.0",
 ]
 
 [[package]]
 name = "polkadot-primitives"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "15.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -11653,23 +11473,22 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 30.0.0",
- "sp-arithmetic 23.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-authority-discovery",
  "sp-consensus-slots",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-inherents",
- "sp-io 30.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
+ "sp-io 38.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.0",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
 name = "polkadot-rpc"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "jsonrpsee 0.23.2",
  "mmr-rpc",
@@ -11689,22 +11508,22 @@ dependencies = [
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
  "sp-api",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-consensus-beefy",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.0",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -11738,14 +11557,13 @@ dependencies = [
  "serde_derive",
  "slot-range-helper",
  "sp-api",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-inherents",
- "sp-io 30.0.0",
+ "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -11754,21 +11572,20 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -11798,16 +11615,15 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 30.0.0",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
  "sp-inherents",
- "sp-io 30.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
+ "sp-io 38.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.0",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
  "staging-xcm",
  "staging-xcm-executor",
  "static_assertions",
@@ -11815,8 +11631,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-sdk"
-version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.5.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -12034,8 +11850,8 @@ dependencies = [
  "snowbridge-system-runtime-api",
  "sp-api",
  "sp-api-proc-macro",
- "sp-application-crypto 30.0.0",
- "sp-arithmetic 23.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-blockchain",
@@ -12046,44 +11862,44 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-consensus-pow",
  "sp-consensus-slots",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-core-hashing",
- "sp-crypto-ec-utils 0.10.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-debug-derive 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-crypto-ec-utils",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-externalities 0.29.0",
  "sp-genesis-builder",
  "sp-inherents",
- "sp-io 30.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
+ "sp-io 38.0.0",
+ "sp-keyring 39.0.0",
+ "sp-keystore 0.40.0",
  "sp-metadata-ir",
  "sp-mixnet",
  "sp-mmr-primitives",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime 31.0.1",
- "sp-runtime-interface 24.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
+ "sp-runtime-interface 28.0.0",
  "sp-session",
  "sp-staking",
- "sp-state-machine 0.35.0",
+ "sp-state-machine 0.43.0",
  "sp-statement-store",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-storage 19.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-storage 21.0.0",
  "sp-timestamp",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-tracing 17.0.0",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie 29.0.0",
+ "sp-trie 37.0.0",
  "sp-version",
- "sp-wasm-interface 20.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-weights 27.0.0",
+ "sp-wasm-interface 21.0.0",
+ "sp-weights 31.0.0",
  "staging-node-inspect",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
- "substrate-bip39 0.4.7",
+ "substrate-bip39 0.6.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
@@ -12094,8 +11910,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-sdk-frame"
-version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.6.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -12109,26 +11925,25 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-arithmetic 23.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-consensus-grandpa",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-inherents",
- "sp-io 30.0.0",
+ "sp-io 38.0.0",
  "sp-offchain",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-storage 19.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-storage 21.0.0",
  "sp-transaction-pool",
  "sp-version",
 ]
 
 [[package]]
 name = "polkadot-service"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -12195,21 +12010,21 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-inherents",
- "sp-io 30.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
+ "sp-io 38.0.0",
+ "sp-keyring 39.0.0",
+ "sp-keystore 0.40.0",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-state-machine 0.35.0",
- "sp-storage 19.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-state-machine 0.43.0",
+ "sp-storage 21.0.0",
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-version",
- "sp-weights 27.0.0",
+ "sp-weights 31.0.0",
  "staging-xcm",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -12220,12 +12035,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-table"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "15.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "tracing-gum",
 ]
 
@@ -12293,7 +12108,7 @@ dependencies = [
  "polkavm-common 0.8.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -12305,7 +12120,7 @@ dependencies = [
  "polkavm-common 0.9.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -12315,7 +12130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e85319a0d5129dc9f021c62607e0804f5fb777a05cdda44d750ac0732def66"
 dependencies = [
  "polkavm-derive-impl 0.8.0",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -12325,7 +12140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl 0.9.0",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -12367,9 +12182,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.2"
+version = "3.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -12377,7 +12192,7 @@ dependencies = [
  "pin-project-lite",
  "rustix 0.38.34",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12422,13 +12237,13 @@ checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "postcard"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
 dependencies = [
  "cobs",
- "const_format",
- "embedded-io",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
  "heapless",
  "postcard-derive",
  "serde",
@@ -12436,9 +12251,9 @@ dependencies = [
 
 [[package]]
 name = "postcard-derive"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4b01218787dd4420daf63875163a787a78294ad48a24e9f6fa8c6507759a79"
+checksum = "0239fa9c1d225d4b7eb69925c25c5e082307a141e470573fbbe3a817ce6a7a37"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12453,15 +12268,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precis-core"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73e9dd26361c32e7cd13d1032bb01c4e26a23287274e8a4e2f228cf2c9ff77b"
+checksum = "25a414cabc93f5f45d53463e73b3d89d3c5c0dc4a34dbf6901f0c6358f017203"
 dependencies = [
  "precis-tools",
  "ucd-parse",
@@ -12470,9 +12288,9 @@ dependencies = [
 
 [[package]]
 name = "precis-profiles"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde4bd6624c60cb0abe2bea1dbdbb9085f629a853861e64df4abb099f8076ad4"
+checksum = "f58e2841ef58164e2626464d4fde67fa301d5e2c78a10300c1756312a03b169f"
 dependencies = [
  "lazy_static",
  "precis-core",
@@ -12482,9 +12300,9 @@ dependencies = [
 
 [[package]]
 name = "precis-tools"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07ecadec70b0f560f09abf815ae0ee1a940d38d2354c938ba7229ac7c9f5f52"
+checksum = "016da884bc4c2c4670211641abef402d15fa2b06c6e9088ff270dac93675aee2"
 dependencies = [
  "lazy_static",
  "regex",
@@ -12554,7 +12372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -12654,7 +12472,7 @@ checksum = "3d1eaa7fa0aa1929ffdf7eeb6eac234dde6268914a14ad44d23521ab6a9b258e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -12665,7 +12483,7 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -12723,7 +12541,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -12818,7 +12636,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.72",
+ "syn 2.0.75",
  "tempfile",
 ]
 
@@ -12845,7 +12663,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -12956,16 +12774,17 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
 dependencies = [
  "bytes",
  "pin-project-lite",
- "quinn-proto 0.11.3",
+ "quinn-proto 0.11.6",
  "quinn-udp 0.5.4",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.0.0",
  "rustls 0.23.12",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
  "tracing",
@@ -13008,14 +12827,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
 dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring 0.17.8",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.0.0",
  "rustls 0.23.12",
  "slab",
  "thiserror",
@@ -13058,6 +12877,7 @@ dependencies = [
  "libc",
  "once_cell",
  "socket2 0.5.7",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -13271,15 +13091,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
@@ -13289,9 +13100,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
@@ -13327,7 +13138,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -13357,9 +13168,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -13443,14 +13254,14 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.25.4",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -13469,9 +13280,9 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn 0.11.2",
+ "quinn 0.11.3",
  "rustls 0.23.12",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -13485,7 +13296,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.26.3",
- "winreg 0.52.0",
+ "windows-registry",
 ]
 
 [[package]]
@@ -13506,23 +13317,6 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac 0.12.1",
  "subtle 2.6.1",
-]
-
-[[package]]
-name = "ring"
-version = "0.1.0"
-source = "git+https://github.com/w3f/ring-proof#665f5f51af5734c7b6d90b985dd6861d4c5b4752"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "arrayvec 0.7.4",
- "blake2 0.10.6",
- "common",
- "fflonk",
- "merlin",
 ]
 
 [[package]]
@@ -13598,8 +13392,8 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -13670,23 +13464,22 @@ dependencies = [
  "serde_json",
  "smallvec",
  "sp-api",
- "sp-arithmetic 23.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-genesis-builder",
  "sp-inherents",
- "sp-io 30.0.0",
+ "sp-io 38.0.0",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-storage 19.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-storage 21.0.0",
  "sp-transaction-pool",
  "sp-version",
  "staging-xcm",
@@ -13699,16 +13492,16 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-weights 31.0.0",
  "staging-xcm",
  "staging-xcm-builder",
 ]
@@ -13716,7 +13509,7 @@ dependencies = [
 [[package]]
 name = "rosetta-client"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13745,7 +13538,7 @@ dependencies = [
 [[package]]
 name = "rosetta-config-astar"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "anyhow",
  "rosetta-core",
@@ -13755,7 +13548,7 @@ dependencies = [
 [[package]]
 name = "rosetta-config-ethereum"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "anyhow",
  "const-hex",
@@ -13775,7 +13568,7 @@ dependencies = [
 [[package]]
 name = "rosetta-config-polkadot"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "anyhow",
  "rosetta-core",
@@ -13786,7 +13579,7 @@ dependencies = [
 [[package]]
 name = "rosetta-core"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13803,7 +13596,7 @@ dependencies = [
 [[package]]
 name = "rosetta-crypto"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "anyhow",
  "bech32",
@@ -13822,19 +13615,19 @@ dependencies = [
  "sha3",
  "sp-core 31.0.0",
  "ss58-registry",
- "substrate-bip39 0.6.0",
+ "substrate-bip39 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
 [[package]]
 name = "rosetta-ethereum-backend"
 version = "0.1.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "async-trait",
  "auto_impl",
  "futures-core",
- "jsonrpsee-core 0.24.0",
+ "jsonrpsee-core 0.24.3",
  "parity-scale-codec",
  "rosetta-ethereum-types",
  "scale-info",
@@ -13845,7 +13638,7 @@ dependencies = [
 [[package]]
 name = "rosetta-ethereum-types"
 version = "0.2.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "bytes",
  "const-hex",
@@ -13879,7 +13672,7 @@ dependencies = [
 [[package]]
 name = "rosetta-server"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13887,7 +13680,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hex",
- "jsonrpsee 0.24.0",
+ "jsonrpsee 0.24.3",
  "pin-project",
  "serde",
  "serde_json",
@@ -13902,7 +13695,7 @@ dependencies = [
 [[package]]
 name = "rosetta-server-astar"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13926,11 +13719,11 @@ dependencies = [
 [[package]]
 name = "rosetta-server-ethereum"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "anyhow",
  "async-trait",
- "fork-tree 13.0.0",
+ "fork-tree 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer",
  "futures-util",
  "hashbrown 0.14.5",
@@ -13954,7 +13747,7 @@ dependencies = [
 [[package]]
 name = "rosetta-server-polkadot"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13975,7 +13768,7 @@ dependencies = [
 [[package]]
 name = "rosetta-tx-ethereum"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "anyhow",
  "rosetta-config-ethereum",
@@ -13986,7 +13779,7 @@ dependencies = [
 [[package]]
 name = "rosetta-tx-polkadot"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "anyhow",
  "blake2-rfc",
@@ -14000,7 +13793,7 @@ dependencies = [
 [[package]]
 name = "rosetta-types"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "serde",
  "serde_json",
@@ -14009,14 +13802,14 @@ dependencies = [
 [[package]]
 name = "rosetta-utils"
 version = "0.1.0"
-source = "git+https://github.com/analog-labs/chain-connectors#dcab7f8103d6a7ec6fffa7dacfcbfc6c88e2519b"
+source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
 dependencies = [
  "bytes",
  "futures-timer",
  "futures-util",
  "generic-array 1.1.0",
  "impl-serde",
- "jsonrpsee-core 0.24.0",
+ "jsonrpsee-core 0.24.3",
  "pin-project",
  "serde",
  "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -14334,12 +14127,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+checksum = "04182dffc9091a404e0fc069ea5cd60e5b866c3adf881eff99a32d048242dffa"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -14356,9 +14149,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
  "base64 0.22.1",
  "rustls-pki-types",
@@ -14366,15 +14159,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3beb939bcd33c269f4bf946cc829fcd336370267c4a927ac0399c84a3151a1"
+checksum = "93bda3f493b9abe5b93b3e7e3ecde0df292f2bd28c0296b90586ee0055ff5123"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -14382,7 +14175,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls 0.23.12",
- "rustls-native-certs 0.7.1",
+ "rustls-native-certs 0.7.2",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.6",
  "security-framework",
@@ -14393,9 +14186,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier-android"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -14502,19 +14295,19 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "23.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "29.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "log",
- "sp-core 28.0.0",
- "sp-wasm-interface 20.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-wasm-interface 21.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.34.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "futures",
@@ -14534,17 +14327,17 @@ dependencies = [
  "sp-api",
  "sp-authority-discovery",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.34.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "futures",
  "futures-timer",
@@ -14557,31 +14350,31 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-block-builder"
-version = "0.33.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.42.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 31.0.1",
- "sp-trie 29.0.0",
+ "sp-runtime 39.0.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "docify",
@@ -14596,30 +14389,30 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "sp-genesis-builder",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-tracing 17.0.0",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "11.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "12.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "sc-cli"
-version = "0.36.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.46.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -14647,11 +14440,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
- "sp-panic-handler 13.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-keyring 39.0.0",
+ "sp-keystore 0.40.0",
+ "sp-panic-handler 13.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-runtime 39.0.0",
  "sp-version",
  "thiserror",
  "tokio",
@@ -14659,8 +14452,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "fnv",
  "futures",
@@ -14673,21 +14466,21 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-database",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
+ "sp-externalities 0.29.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "sp-statement-store",
- "sp-storage 19.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-storage 21.0.0",
+ "sp-trie 37.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
-version = "0.35.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -14701,19 +14494,19 @@ dependencies = [
  "sc-client-api",
  "sc-state-db",
  "schnellru",
- "sp-arithmetic 23.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-database",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
- "sp-trie 29.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "sc-consensus"
-version = "0.33.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.43.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "futures",
@@ -14727,20 +14520,20 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.34.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
- "fork-tree 12.0.0",
+ "fork-tree 13.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "futures",
  "log",
  "num-bigint",
@@ -14755,25 +14548,25 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool-api",
  "sp-api",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-consensus-slots",
- "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "sp-inherents",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.34.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "futures",
  "jsonrpsee 0.23.2",
@@ -14782,20 +14575,20 @@ dependencies = [
  "sc-rpc-api",
  "serde",
  "sp-api",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-core 28.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "23.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -14813,15 +14606,15 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "sp-api",
- "sp-application-crypto 30.0.0",
- "sp-arithmetic 23.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
- "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -14830,8 +14623,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "23.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "futures",
  "jsonrpsee 0.23.2",
@@ -14841,37 +14634,37 @@ dependencies = [
  "sc-consensus-beefy",
  "sc-rpc",
  "serde",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-beefy",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.33.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.43.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
- "fork-tree 12.0.0",
+ "fork-tree 13.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.19.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.29.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "ahash 0.8.11",
  "array-bytes",
  "async-trait",
  "dyn-clone",
  "finality-grandpa",
- "fork-tree 12.0.0",
+ "fork-tree 13.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "futures",
  "futures-timer",
  "log",
@@ -14892,23 +14685,23 @@ dependencies = [
  "sc-utils",
  "serde_json",
  "sp-api",
- "sp-application-crypto 30.0.0",
- "sp-arithmetic 23.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.19.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.29.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -14920,15 +14713,15 @@ dependencies = [
  "sc-rpc",
  "serde",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.33.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.43.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "futures",
@@ -14938,20 +14731,20 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sc-telemetry",
- "sp-arithmetic 23.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
 ]
 
 [[package]]
 name = "sc-executor"
-version = "0.32.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.40.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -14960,45 +14753,45 @@ dependencies = [
  "sc-executor-wasmtime",
  "schnellru",
  "sp-api",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-io 30.0.0",
- "sp-panic-handler 13.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-io 38.0.0",
+ "sp-panic-handler 13.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-runtime-interface 28.0.0",
+ "sp-trie 37.0.0",
  "sp-version",
- "sp-wasm-interface 20.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-wasm-interface 21.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "sc-executor-common"
-version = "0.29.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.35.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "polkavm",
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface 20.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-wasm-interface 21.0.0",
  "thiserror",
  "wasm-instrument",
 ]
 
 [[package]]
 name = "sc-executor-polkavm"
-version = "0.29.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.32.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "log",
  "polkavm",
  "sc-executor-common",
- "sp-wasm-interface 20.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-wasm-interface 21.0.0",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.29.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.35.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -15008,15 +14801,15 @@ dependencies = [
  "rustix 0.36.17",
  "sc-allocator",
  "sc-executor-common",
- "sp-runtime-interface 24.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime-interface 28.0.0",
+ "sp-wasm-interface 21.0.0",
  "wasmtime",
 ]
 
 [[package]]
 name = "sc-informant"
-version = "0.33.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.43.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "ansi_term",
  "futures",
@@ -15027,30 +14820,30 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sc-keystore"
-version = "25.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "33.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
  "serde_json",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-keystore 0.34.0",
+ "sp-application-crypto 38.0.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-mixnet"
-version = "0.4.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.14.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "blake2 0.10.6",
  "bytes",
  "futures",
@@ -15066,17 +14859,17 @@ dependencies = [
  "sc-transaction-pool-api",
  "sp-api",
  "sp-consensus",
- "sp-core 28.0.0",
- "sp-keystore 0.34.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
  "sp-mixnet",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.34.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -15110,10 +14903,10 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-arithmetic 23.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -15126,8 +14919,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.33.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.43.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -15139,13 +14932,13 @@ dependencies = [
  "sc-network-types",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.34.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "ahash 0.8.11",
  "futures",
@@ -15156,15 +14949,15 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "schnellru",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "sc-network-light"
-version = "0.33.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.43.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -15177,20 +14970,20 @@ dependencies = [
  "sc-network",
  "sc-network-types",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network-sync"
-version = "0.33.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.43.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
- "fork-tree 12.0.0",
+ "fork-tree 13.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "futures",
  "futures-timer",
  "libp2p",
@@ -15207,12 +15000,12 @@ dependencies = [
  "sc-utils",
  "schnellru",
  "smallvec",
- "sp-arithmetic 23.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -15221,8 +15014,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.33.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.43.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "futures",
@@ -15234,14 +15027,14 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-network-types"
-version = "0.10.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.12.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -15257,8 +15050,8 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "29.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "39.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -15280,19 +15073,19 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "sp-api",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-keystore 0.34.0",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-keystore 0.40.0",
  "sp-offchain",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "threadpool",
  "tracing",
 ]
 
 [[package]]
 name = "sc-proposer-metrics"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -15300,8 +15093,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "29.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "39.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "futures",
  "jsonrpsee 0.23.2",
@@ -15319,11 +15112,11 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-keystore 0.34.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-session",
  "sp-statement-store",
  "sp-version",
@@ -15332,8 +15125,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.33.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.43.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "jsonrpsee 0.23.2",
  "parity-scale-codec",
@@ -15343,17 +15136,17 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-version",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-rpc-server"
-version = "11.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "forwarded-header-value",
  "futures",
@@ -15374,8 +15167,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.34.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "futures",
@@ -15395,9 +15188,9 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-version",
  "thiserror",
  "tokio",
@@ -15406,8 +15199,8 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.35.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.45.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "directories",
@@ -15448,16 +15241,16 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-state-machine 0.35.0",
- "sp-storage 19.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-state-machine 0.43.0",
+ "sp-storage 21.0.0",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie 29.0.0",
+ "sp-trie 37.0.0",
  "sp-version",
  "static_init",
  "substrate-prometheus-endpoint",
@@ -15470,32 +15263,32 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.30.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.36.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
 ]
 
 [[package]]
 name = "sc-storage-monitor"
-version = "0.16.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.22.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "clap",
  "fs4",
  "log",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.34.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "jsonrpsee 0.23.2",
  "parity-scale-codec",
@@ -15507,14 +15300,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-sysinfo"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "derive_more 0.99.18",
  "futures",
@@ -15526,16 +15319,16 @@ dependencies = [
  "sc-telemetry",
  "serde",
  "serde_json",
- "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-io 30.0.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-io 38.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "15.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "24.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "chrono",
  "futures",
@@ -15554,8 +15347,8 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -15572,10 +15365,10 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime 31.0.1",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
+ "sp-tracing 17.0.0",
  "thiserror",
  "tracing",
  "tracing-log 0.2.0",
@@ -15585,18 +15378,18 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "futures",
@@ -15611,10 +15404,10 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-runtime 31.0.1",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-runtime 39.0.0",
+ "sp-tracing 17.0.0",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -15622,8 +15415,8 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "futures",
@@ -15631,15 +15424,15 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-utils"
-version = "14.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -15648,7 +15441,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "prometheus",
- "sp-arithmetic 23.0.0",
+ "sp-arithmetic 26.0.0",
 ]
 
 [[package]]
@@ -15763,15 +15556,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "syn 2.0.72",
+ "syn 2.0.75",
  "thiserror",
 ]
 
 [[package]]
 name = "scale-value"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab68da501822d2769c4c5823535f6104a6d4cd15f0d3eba3e647e725294ae22"
+checksum = "ba4d772cfb7569e03868400344a1695d16560bf62b86b918604773607d39ec84"
 dependencies = [
  "base58",
  "blake2 0.10.6",
@@ -15831,7 +15624,7 @@ checksum = "8de18f6d8ba0aad7045f5feae07ec29899c1112584a38509a84ad7b04451eaa0"
 dependencies = [
  "aead 0.5.2",
  "arrayref",
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "curve25519-dalek 4.1.3",
  "getrandom_or_panic",
  "merlin",
@@ -15841,6 +15634,12 @@ dependencies = [
  "subtle 2.6.1",
  "zeroize",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -16026,9 +15825,9 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
@@ -16062,22 +15861,23 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -16220,9 +16020,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b57fd861253bff08bb1919e995f90ba8f4889de2726091c8876f3a4e823b40"
+checksum = "57d79b758b7cb2085612b11a235055e485605a5103faccdd633f35bd7aee69dd"
 dependencies = [
  "cc",
  "cfg-if",
@@ -16239,12 +16039,12 @@ dependencies = [
 
 [[package]]
 name = "shared_child"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
+checksum = "09fa9338aed9a1df411814a5b2252f7cd206c55ae9bf2fa763f8de84603aa60c"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16338,14 +16138,13 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slot-range-helper"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "15.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -16356,14 +16155,14 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smol"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e635339259e51ef85ac7aa29a1cd991b957047507288697a690e80ab97d07cad"
+checksum = "aad24f41392790e6ac67f4f4cd871da61f7d758e07b5622431e491e897d9c8a7"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
  "async-fs",
- "async-io 2.3.3",
+ "async-io 2.3.4",
  "async-lock 3.4.0",
  "async-net",
  "async-process",
@@ -16377,7 +16176,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d1eaa97d77be4d026a1e7ffad1bb3b78448763b357ea6f8188d3e6f736a9b9"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "async-lock 3.4.0",
  "atomic-take",
  "base64 0.21.7",
@@ -16447,7 +16246,7 @@ dependencies = [
  "hex",
  "itertools 0.12.1",
  "log",
- "lru 0.12.3",
+ "lru 0.12.4",
  "no-std-net",
  "parking_lot 0.12.3",
  "pin-project",
@@ -16497,8 +16296,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-beacon-primitives"
-version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -16509,18 +16308,18 @@ dependencies = [
  "serde",
  "snowbridge-ethereum",
  "snowbridge-milagro-bls",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "ssz_rs",
  "ssz_rs_derive",
 ]
 
 [[package]]
 name = "snowbridge-core"
-version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -16531,19 +16330,19 @@ dependencies = [
  "scale-info",
  "serde",
  "snowbridge-beacon-primitives",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "staging-xcm",
  "staging-xcm-builder",
 ]
 
 [[package]]
 name = "snowbridge-ethereum"
-version = "0.3.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "ethabi-decode",
  "ethbloom",
@@ -16555,9 +16354,9 @@ dependencies = [
  "scale-info",
  "serde",
  "serde-big-array",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
@@ -16577,32 +16376,32 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-merkle-tree"
-version = "0.3.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
-version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "snowbridge-core",
  "snowbridge-outbound-queue-merkle-tree",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "snowbridge-pallet-ethereum-client"
-version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -16617,29 +16416,29 @@ dependencies = [
  "snowbridge-core",
  "snowbridge-ethereum",
  "snowbridge-pallet-ethereum-client-fixtures",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "static_assertions",
 ]
 
 [[package]]
 name = "snowbridge-pallet-ethereum-client-fixtures"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
  "snowbridge-core",
- "sp-core 28.0.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "snowbridge-pallet-inbound-queue"
-version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "alloy-primitives 0.4.2",
  "alloy-sol-types 0.4.2",
@@ -16656,30 +16455,30 @@ dependencies = [
  "snowbridge-core",
  "snowbridge-pallet-inbound-queue-fixtures",
  "snowbridge-router-primitives",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "staging-xcm",
  "staging-xcm-executor",
 ]
 
 [[package]]
 name = "snowbridge-pallet-inbound-queue-fixtures"
-version = "0.10.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
  "snowbridge-core",
- "sp-core 28.0.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "snowbridge-pallet-outbound-queue"
-version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -16691,17 +16490,17 @@ dependencies = [
  "serde",
  "snowbridge-core",
  "snowbridge-outbound-queue-merkle-tree",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "snowbridge-pallet-system"
-version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -16710,18 +16509,18 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "snowbridge-core",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "staging-xcm",
  "staging-xcm-executor",
 ]
 
 [[package]]
 name = "snowbridge-router-primitives"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.15.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -16729,25 +16528,25 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "snowbridge-core",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "staging-xcm",
  "staging-xcm-executor",
 ]
 
 [[package]]
 name = "snowbridge-runtime-common"
-version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "log",
  "parity-scale-codec",
  "snowbridge-core",
- "sp-arithmetic 23.0.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-arithmetic 26.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -16755,8 +16554,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-runtime-test-common"
-version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -16775,10 +16574,10 @@ dependencies = [
  "snowbridge-pallet-ethereum-client-fixtures",
  "snowbridge-pallet-outbound-queue",
  "snowbridge-pallet-system",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-keyring 31.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-keyring 39.0.0",
+ "sp-runtime 39.0.0",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
@@ -16786,13 +16585,13 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-system-runtime-api"
-version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "staging-xcm",
 ]
 
@@ -16863,8 +16662,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "hash-db",
@@ -16872,22 +16671,21 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api-proc-macro",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
  "sp-metadata-ir",
- "sp-runtime 31.0.1",
- "sp-runtime-interface 24.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
+ "sp-runtime 39.0.0",
+ "sp-runtime-interface 28.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
  "sp-version",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "15.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "20.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -16895,20 +16693,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "sp-application-crypto"
-version = "30.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -16926,18 +16711,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-arithmetic"
-version = "23.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+name = "sp-application-crypto"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
- "docify",
- "integer-sqrt",
- "num-traits",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "static_assertions",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
 ]
 
 [[package]]
@@ -16956,136 +16738,133 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-ark-bls12-381"
-version = "0.4.2"
-source = "git+https://github.com/paritytech/arkworks-substrate#caa2eed74beb885dd07c7db5f916f2281dad818f"
+name = "sp-arithmetic"
+version = "26.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
- "ark-bls12-381-ext",
- "sp-crypto-ec-utils 0.10.0 (git+https://github.com/paritytech/polkadot-sdk)",
-]
-
-[[package]]
-name = "sp-ark-ed-on-bls12-381-bandersnatch"
-version = "0.4.2"
-source = "git+https://github.com/paritytech/arkworks-substrate#caa2eed74beb885dd07c7db5f916f2281dad818f"
-dependencies = [
- "ark-ed-on-bls12-381-bandersnatch-ext",
- "sp-crypto-ec-utils 0.10.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "docify",
+ "integer-sqrt",
+ "num-traits",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
 name = "sp-authority-discovery"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto 30.0.0",
- "sp-runtime 31.0.1",
+ "sp-application-crypto 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sp-block-builder"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "sp-api",
  "sp-inherents",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sp-blockchain"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "futures",
- "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "schnellru",
  "sp-api",
  "sp-consensus",
+ "sp-core 34.0.0",
  "sp-database",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "sp-consensus"
-version = "0.32.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.40.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "futures",
  "log",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.32.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.40.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-slots",
  "sp-inherents",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.32.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.40.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-slots",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "22.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-io 30.0.0",
- "sp-keystore 0.34.0",
+ "sp-application-crypto 38.0.0",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-io 38.0.0",
+ "sp-keystore 0.40.0",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "strum 0.26.3",
 ]
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "21.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -17093,79 +16872,32 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
+ "sp-application-crypto 38.0.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sp-consensus-pow"
-version = "0.32.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.40.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.32.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.40.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-timestamp",
-]
-
-[[package]]
-name = "sp-core"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
-dependencies = [
- "array-bytes",
- "bandersnatch_vrfs",
- "bitflags 1.3.2",
- "blake2 0.10.6",
- "bounded-collections",
- "bs58 0.5.1",
- "dyn-clonable",
- "ed25519-zebra 4.0.3",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "impl-serde",
- "itertools 0.11.0",
- "k256",
- "libsecp256k1",
- "log",
- "merlin",
- "parity-bip39",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "paste",
- "primitive-types",
- "rand 0.8.5",
- "scale-info",
- "schnorrkel",
- "secp256k1",
- "secrecy",
- "serde",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-debug-derive 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-storage 19.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "ss58-registry",
- "substrate-bip39 0.4.7",
- "thiserror",
- "tracing",
- "w3f-bls",
- "zeroize",
 ]
 
 [[package]]
@@ -17216,17 +16948,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-core"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
+dependencies = [
+ "array-bytes",
+ "bitflags 1.3.2",
+ "blake2 0.10.6",
+ "bounded-collections",
+ "bs58 0.5.1",
+ "dyn-clonable",
+ "ed25519-zebra 4.0.3",
+ "futures",
+ "hash-db",
+ "hash256-std-hasher",
+ "impl-serde",
+ "itertools 0.11.0",
+ "k256",
+ "libsecp256k1",
+ "log",
+ "merlin",
+ "parity-bip39",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "paste",
+ "primitive-types",
+ "rand 0.8.5",
+ "scale-info",
+ "schnorrkel",
+ "secp256k1",
+ "secrecy",
+ "serde",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-externalities 0.29.0",
+ "sp-runtime-interface 28.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-storage 21.0.0",
+ "ss58-registry",
+ "substrate-bip39 0.6.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "thiserror",
+ "tracing",
+ "w3f-bls",
+ "zeroize",
+]
+
+[[package]]
 name = "sp-core-hashing"
-version = "15.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
 name = "sp-crypto-ec-utils"
-version = "0.10.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.14.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -17240,27 +17018,7 @@ dependencies = [
  "ark-ed-on-bls12-381-bandersnatch",
  "ark-ed-on-bls12-381-bandersnatch-ext",
  "ark-scale",
- "sp-runtime-interface 24.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
-]
-
-[[package]]
-name = "sp-crypto-ec-utils"
-version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#18db502172bdf438f086cd5964c646b318b8ad37"
-dependencies = [
- "ark-bls12-377",
- "ark-bls12-377-ext",
- "ark-bls12-381",
- "ark-bls12-381-ext",
- "ark-bw6-761",
- "ark-bw6-761-ext",
- "ark-ec",
- "ark-ed-on-bls12-377",
- "ark-ed-on-bls12-377-ext",
- "ark-ed-on-bls12-381-bandersnatch",
- "ark-ed-on-bls12-381-bandersnatch-ext",
- "ark-scale",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-runtime-interface 28.0.0",
 ]
 
 [[package]]
@@ -17280,7 +17038,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -17293,17 +17051,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "syn 2.0.72",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -17317,47 +17075,17 @@ checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "sp-debug-derive"
-version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#18db502172bdf438f086cd5964c646b318b8ad37"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.25.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-storage 19.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#18db502172bdf438f086cd5964c646b318b8ad37"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -17373,55 +17101,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-externalities"
+version = "0.29.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
+dependencies = [
+ "environmental",
+ "parity-scale-codec",
+ "sp-storage 21.0.0",
+]
+
+[[package]]
 name = "sp-genesis-builder"
-version = "0.8.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.15.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
  "sp-api",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sp-inherents"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "thiserror",
-]
-
-[[package]]
-name = "sp-io"
-version = "30.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
-dependencies = [
- "bytes",
- "docify",
- "ed25519-dalek",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive 0.9.1",
- "rustversion",
- "secp256k1",
- "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-keystore 0.34.0",
- "sp-runtime-interface 24.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
- "tracing",
- "tracing-core",
 ]
 
 [[package]]
@@ -17445,20 +17156,36 @@ dependencies = [
  "sp-runtime-interface 26.0.0",
  "sp-state-machine 0.38.0",
  "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 16.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-tracing 16.0.0",
  "sp-trie 32.0.0",
  "tracing",
  "tracing-core",
 ]
 
 [[package]]
-name = "sp-keyring"
-version = "31.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+name = "sp-io"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "strum 0.26.3",
+ "bytes",
+ "docify",
+ "ed25519-dalek",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "polkavm-derive 0.9.1",
+ "rustversion",
+ "secp256k1",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-externalities 0.29.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime-interface 28.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-tracing 17.0.0",
+ "sp-trie 37.0.0",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -17473,14 +17200,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-keystore"
-version = "0.34.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+name = "sp-keyring"
+version = "39.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -17496,9 +17222,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-keystore"
+version = "0.40.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
+dependencies = [
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+]
+
+[[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -17506,8 +17243,8 @@ dependencies = [
 
 [[package]]
 name = "sp-metadata-ir"
-version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.7.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -17516,19 +17253,19 @@ dependencies = [
 
 [[package]]
 name = "sp-mixnet"
-version = "0.4.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.12.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto 30.0.0",
+ "sp-application-crypto 38.0.0",
 ]
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -17536,33 +17273,33 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-core 28.0.0",
- "sp-debug-derive 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-debug-derive 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-npos-elections"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sp-offchain"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "sp-api",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -17579,7 +17316,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -17588,37 +17325,12 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "32.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
- "sp-core 28.0.0",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "31.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
-dependencies = [
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "num-traits",
- "parity-scale-codec",
- "paste",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 30.0.0",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-weights 27.0.0",
+ "sp-core 34.0.0",
 ]
 
 [[package]]
@@ -17647,41 +17359,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-runtime-interface"
-version = "24.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+name = "sp-runtime"
+version = "39.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
- "bytes",
+ "docify",
+ "either",
+ "hash256-std-hasher",
  "impl-trait-for-tuples",
+ "log",
+ "num-traits",
  "parity-scale-codec",
- "polkavm-derive 0.9.1",
- "primitive-types",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-storage 19.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#18db502172bdf438f086cd5964c646b318b8ad37"
-dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "polkavm-derive 0.9.1",
- "primitive-types",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "static_assertions",
+ "paste",
+ "rand 0.8.5",
+ "scale-info",
+ "serde",
+ "simple-mermaid",
+ "sp-application-crypto 38.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-weights 31.0.0",
+ "tracing",
 ]
 
 [[package]]
@@ -17696,38 +17396,31 @@ dependencies = [
  "polkavm-derive 0.8.0",
  "primitive-types",
  "sp-externalities 0.27.0",
- "sp-runtime-interface-proc-macro 18.0.0",
+ "sp-runtime-interface-proc-macro 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-storage 20.0.0",
- "sp-tracing 16.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-wasm-interface 20.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-tracing 16.0.0",
+ "sp-wasm-interface 20.0.0",
  "static_assertions",
 ]
 
 [[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+name = "sp-runtime-interface"
+version = "28.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
- "Inflector",
- "expander",
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#18db502172bdf438f086cd5964c646b318b8ad37"
-dependencies = [
- "Inflector",
- "expander",
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
- "syn 2.0.72",
+ "bytes",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "polkavm-derive 0.9.1",
+ "primitive-types",
+ "sp-externalities 0.29.0",
+ "sp-runtime-interface-proc-macro 18.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-storage 21.0.0",
+ "sp-tracing 17.0.0",
+ "sp-wasm-interface 21.0.0",
+ "static_assertions",
 ]
 
 [[package]]
@@ -17741,54 +17434,47 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
+]
+
+[[package]]
+name = "sp-runtime-interface-proc-macro"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
+dependencies = [
+ "Inflector",
+ "expander",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "sp-session"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "35.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-core 28.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.0",
  "sp-staking",
 ]
 
 [[package]]
 name = "sp-staking"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.35.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand 0.8.5",
- "smallvec",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-panic-handler 13.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-trie 29.0.0",
- "thiserror",
- "tracing",
- "trie-db 0.29.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -17814,9 +17500,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-state-machine"
+version = "0.43.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "smallvec",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-panic-handler 13.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-trie 37.0.0",
+ "thiserror",
+ "tracing",
+ "trie-db 0.29.1",
+]
+
+[[package]]
 name = "sp-statement-store"
-version = "10.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "aes-gcm 0.10.3",
  "curve25519-dalek 4.1.3",
@@ -17827,12 +17533,12 @@ dependencies = [
  "scale-info",
  "sha2 0.10.8",
  "sp-api",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-runtime 31.0.1",
- "sp-runtime-interface 24.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-application-crypto 38.0.0",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+ "sp-externalities 0.29.0",
+ "sp-runtime 39.0.0",
+ "sp-runtime-interface 28.0.0",
  "thiserror",
  "x25519-dalek",
 ]
@@ -17846,36 +17552,7 @@ checksum = "12f8ee986414b0a9ad741776762f4083cd3a5128449b982a3919c4df36874834"
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
-
-[[package]]
-name = "sp-std"
-version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#18db502172bdf438f086cd5964c646b318b8ad37"
-
-[[package]]
-name = "sp-storage"
-version = "19.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
-]
-
-[[package]]
-name = "sp-storage"
-version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#18db502172bdf438f086cd5964c646b318b8ad37"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
-]
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 
 [[package]]
 name = "sp-storage"
@@ -17892,14 +17569,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-storage"
+version = "21.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "ref-cast",
+ "serde",
+ "sp-debug-derive 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
+]
+
+[[package]]
 name = "sp-timestamp"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "sp-inherents",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
@@ -17918,19 +17607,8 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
-dependencies = [
- "parity-scale-codec",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.3.18",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#18db502172bdf438f086cd5964c646b318b8ad37"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -17940,48 +17618,25 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "sp-api",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "34.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 31.0.1",
- "sp-trie 29.0.0",
-]
-
-[[package]]
-name = "sp-trie"
-version = "29.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
-dependencies = [
- "ahash 0.8.11",
- "hash-db",
- "lazy_static",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand 0.8.5",
- "scale-info",
- "schnellru",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "thiserror",
- "tracing",
- "trie-db 0.29.1",
- "trie-root",
+ "sp-runtime 39.0.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
@@ -18010,9 +17665,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-trie"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
+dependencies = [
+ "ahash 0.8.11",
+ "hash-db",
+ "lazy_static",
+ "memory-db",
+ "nohash-hasher",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "scale-info",
+ "schnellru",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "thiserror",
+ "tracing",
+ "trie-db 0.29.1",
+ "trie-root",
+]
+
+[[package]]
 name = "sp-version"
-version = "29.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18020,21 +17698,21 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "sp-version-proc-macro",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-version-proc-macro"
-version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "14.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -18053,38 +17731,14 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "20.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "21.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "wasmtime",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#18db502172bdf438f086cd5964c646b318b8ad37"
-dependencies = [
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
-]
-
-[[package]]
-name = "sp-weights"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
-dependencies = [
- "bounded-collections",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "smallvec",
- "sp-arithmetic 23.0.0",
- "sp-debug-derive 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
 ]
 
 [[package]]
@@ -18101,6 +17755,20 @@ dependencies = [
  "sp-arithmetic 25.0.0",
  "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sp-weights"
+version = "31.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
+dependencies = [
+ "bounded-collections",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "smallvec",
+ "sp-arithmetic 26.0.0",
+ "sp-debug-derive 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
 ]
 
 [[package]]
@@ -18224,8 +17892,8 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-node-inspect"
-version = "0.12.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.22.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -18233,31 +17901,30 @@ dependencies = [
  "sc-client-api",
  "sc-service",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-statement-store",
  "thiserror",
 ]
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "staging-xcm"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "14.1.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -18268,14 +17935,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-weights 27.0.0",
+ "sp-weights 31.0.0",
  "xcm-procedural",
 ]
 
 [[package]]
 name = "staging-xcm-builder"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -18285,34 +17952,32 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-weights 27.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-weights 31.0.0",
  "staging-xcm",
  "staging-xcm-executor",
 ]
 
 [[package]]
 name = "staging-xcm-executor"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "environmental",
  "frame-benchmarking",
  "frame-support",
  "impl-trait-for-tuples",
- "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-weights 27.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-weights 31.0.0",
  "staging-xcm",
+ "tracing",
 ]
 
 [[package]]
@@ -18483,7 +18148,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "struct_iterable_internal",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -18533,7 +18198,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -18558,18 +18223,6 @@ dependencies = [
  "precis-profiles",
  "quoted-string-parser",
  "rand 0.8.5",
-]
-
-[[package]]
-name = "substrate-bip39"
-version = "0.4.7"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
-dependencies = [
- "hmac 0.12.1",
- "pbkdf2 0.12.2",
- "schnorrkel",
- "sha2 0.10.8",
- "zeroize",
 ]
 
 [[package]]
@@ -18599,14 +18252,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-bip39"
+version = "0.6.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
+dependencies = [
+ "hmac 0.12.1",
+ "pbkdf2 0.12.2",
+ "schnorrkel",
+ "sha2 0.10.8",
+ "zeroize",
+]
+
+[[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -18619,16 +18284,18 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
- "hyper 0.14.30",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
  "log",
  "prometheus",
  "thiserror",
@@ -18637,25 +18304,25 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "jsonrpsee 0.23.2",
  "parity-scale-codec",
  "sc-client-api",
  "sc-rpc-api",
  "serde",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
- "sp-trie 29.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
  "trie-db 0.29.1",
 ]
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "24.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -18668,14 +18335,14 @@ dependencies = [
  "parity-wasm",
  "polkavm-linker",
  "sc-executor",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
  "sp-maybe-compressed-blob",
- "sp-tracing 16.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-tracing 17.0.0",
  "sp-version",
  "strum 0.26.3",
  "tempfile",
- "toml 0.8.16",
+ "toml 0.8.19",
  "walkdir",
  "wasm-opt",
 ]
@@ -18744,7 +18411,7 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata",
- "syn 2.0.72",
+ "syn 2.0.75",
  "thiserror",
  "tokio",
 ]
@@ -18807,7 +18474,7 @@ dependencies = [
  "quote",
  "scale-typegen",
  "subxt-codegen",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -18916,9 +18583,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -18934,7 +18601,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -18946,7 +18613,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -18960,6 +18627,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -18981,7 +18651,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -19073,9 +18743,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tc-subxt"
@@ -19099,14 +18769,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand 2.1.0",
+ "once_cell",
  "rustix 0.38.34",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -19172,15 +18843,15 @@ dependencies = [
 
 [[package]]
 name = "testnet-parachains-constants"
-version = "1.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "9.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
  "polkadot-core-primitives",
  "rococo-runtime-constants",
  "smallvec",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "staging-xcm",
  "westend-runtime-constants",
 ]
@@ -19223,7 +18894,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -19449,9 +19120,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.1"
+version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
+checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
 dependencies = [
  "backtrace",
  "bytes",
@@ -19473,7 +19144,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -19615,21 +19286,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.17",
+ "toml_edit 0.22.20",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
@@ -19640,22 +19311,22 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.17"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.16",
+ "winnow 0.6.18",
 ]
 
 [[package]]
@@ -19692,15 +19363,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -19722,7 +19393,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -19747,8 +19418,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "15.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -19759,13 +19430,13 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "expander",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -20132,9 +19803,9 @@ checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
 
 [[package]]
 name = "universal-hash"
@@ -20192,9 +19863,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72139d247e5f97a3eff96229a7ae85ead5328a39efe76f8bf5a06313d505b6ea"
+checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -20255,13 +19926,13 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "visibility"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3fd98999db9227cf28e59d83e1f120f42bc233d4b152e8fab9bc87d5bb1e0f8"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -20351,34 +20022,35 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -20388,9 +20060,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -20398,22 +20070,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-instrument"
@@ -20498,7 +20170,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50386c99b9c32bd2ed71a55b6dd4040af2580530fae8bdb9a6576571a80d0cca"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "multi-stash",
  "num-derive",
  "num-traits",
@@ -20778,9 +20450,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -20832,8 +20504,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -20909,24 +20581,23 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "sp-api",
- "sp-application-crypto 30.0.0",
- "sp-arithmetic 23.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-arithmetic 26.0.0",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
- "sp-core 28.0.0",
+ "sp-core 34.0.0",
  "sp-genesis-builder",
  "sp-inherents",
- "sp-io 30.0.0",
+ "sp-io 38.0.0",
  "sp-mmr-primitives",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime 31.0.1",
+ "sp-runtime 39.0.0",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-storage 19.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-storage 21.0.0",
  "sp-transaction-pool",
  "sp-version",
  "staging-xcm",
@@ -20939,16 +20610,16 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-weights 31.0.0",
  "staging-xcm",
  "staging-xcm-builder",
 ]
@@ -20967,9 +20638,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.26"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901e8597c777fa042e9e245bd56c0dc4418c5db3f845b6ff94fbac732c6a0692"
+checksum = "b828f995bf1e9622031f8009f8481a85406ce1f4d4588ff746d872043e855690"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -20999,11 +20670,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -21029,8 +20700,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core 0.52.0",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.52.0",
+ "windows-interface 0.52.0",
  "windows-targets 0.52.6",
 ]
 
@@ -21041,6 +20712,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
  "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -21068,7 +20749,20 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
- "windows-result",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings",
  "windows-targets 0.52.6",
 ]
 
@@ -21080,7 +20774,18 @@ checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -21091,7 +20796,29 @@ checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-strings",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -21100,6 +20827,25 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 
@@ -21141,6 +20887,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -21334,9 +21089,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.16"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -21346,16 +21101,6 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
@@ -21419,7 +21164,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs 0.6.1",
+ "asn1-rs 0.6.2",
  "data-encoding",
  "der-parser 9.0.0",
  "lazy_static",
@@ -21432,34 +21177,33 @@ dependencies = [
 
 [[package]]
 name = "xcm-procedural"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "10.1.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "0.3.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
- "sp-weights 27.0.0",
+ "sp-weights 31.0.0",
  "staging-xcm",
  "staging-xcm-executor",
 ]
 
 [[package]]
 name = "xcm-simulator"
-version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0#98ab560c22b241cef18169bd419553bbad7a7a0b"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0#066faa1fa2f673f5ce0e9df271bf0d04c56ef841"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -21470,9 +21214,9 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-runtime-parachains",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.14.0-anlog0)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std 14.0.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.1-anlog0)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -21480,9 +21224,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
+checksum = "539a77ee7c0de333dcc6da69b177380a0b81e0dacfa4f7344c465a36871ee601"
 
 [[package]]
 name = "xmltree"
@@ -21541,6 +21285,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -21552,7 +21297,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -21572,7 +21317,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -21635,9 +21380,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.12+zstd.1.5.6"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,10 +57,10 @@ scale-decode = { version = "0.13.1", default-features = false, features = [ "der
 scale-info = { version = "2.11.3", default-features = false, features = [ "derive" ] }
 
 # main substrate sdk
-polkadot-sdk = { git = "https://github.com/Analog-Labs/polkadot-sdk", tag = "v1.14.0-anlog0", default-features = false }
+polkadot-sdk = { git = "https://github.com/Analog-Labs/polkadot-sdk", tag = "v1.15.1-anlog0", default-features = false }
 
 # specialized wasm builder
-substrate-wasm-builder = { git = "https://github.com/analog-labs/polkadot-sdk", tag = "v1.14.0-anlog0", features = [ "metadata-hash" ] }
+substrate-wasm-builder = { git = "https://github.com/analog-labs/polkadot-sdk", tag = "v1.15.1-anlog0", features = [ "metadata-hash" ] }
 
 # chain connectors
 rosetta-client = { git = "https://github.com/analog-labs/chain-connectors" }


### PR DESCRIPTION
## Description

This updates substrate to the latest stable release, most notably including a fix for the finality stalling issue (paritytech/polkadot-sdk#5153).

Fixes #1077.