### PR TITLE
node: add --sta flag to cli

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -11,6 +11,14 @@ pub struct Cli {
 	#[clap(flatten)]
 	pub run: sc_cli::RunCmd,
 
+	/// Specify the staging chain.
+	///
+	/// This flag sets `--chain=sta`, `--force-authoring`, `--rpc-cors=all`,
+	/// `--alice`, and `--tmp` flags, unless explicitly overridden.
+	/// It also disables local peer discovery (see --no-mdns and --discover-local)
+	#[arg(long, conflicts_with_all = &["dev", "chain"])]
+	pub sta: bool,
+
 	/// Disable automatic hardware benchmarks.
 	///
 	/// By default these benchmarks are automatically ran at startup and measure

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -86,7 +86,7 @@ impl SubstrateCli for Cli {
 
 #[allow(clippy::extra_unused_type_parameters)]
 /// Parse command line arguments into service configuration.
-pub fn run_with<Runtime, RuntimeApi>(cli: Cli) -> sc_cli::Result<()>
+pub fn run_with<Runtime, RuntimeApi>(mut cli: Cli) -> sc_cli::Result<()>
 where
 	Runtime: frame_system::Config + pallet_transaction_payment::Config + Send + Sync,
 	RuntimeApi: sp_api::ConstructRuntimeApi<Block, FullClient<RuntimeApi>> + Send + Sync + 'static,
@@ -102,6 +102,13 @@ where
 		+ frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Nonce>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 {
+	// Support for custom "--sta" flag
+	if cli.sta {
+		cli.run.shared_params.dev = true;
+		cli.run.shared_params.chain = Some("sta".to_string());
+	}
+
+	// Parse subcommand to determine what to run
 	match &cli.subcommand {
 		None => {
 			let runner = cli.create_runner(&cli.run)?;


### PR DESCRIPTION
## Description

To make mainnet testing easier and less verbose, this PR adds the `--sta` flag to the command line interface. It acts just like the `--dev` flag, but for the mainnet runtime and chain.