### PR TITLE
ci: update outdate checkout actions

### DIFF
--- a/.github/workflows/cron-upload-state.yaml
+++ b/.github/workflows/cron-upload-state.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y librocksdb-dev protobuf-compiler clang
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install rust toolchain
       shell: bash
       run: rustup show
@@ -40,7 +40,7 @@ jobs:
         aws configure set aws_secret_access_key $UPLOAD_SECRET_ACCESS_KEY
         aws configure set region $AWS_REGION
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Generate state
       run: try-runtime create-snapshot --uri ${{ matrix.url }} ${{ matrix.chain}}-state.snap
     - name: Upload to S3

--- a/.github/workflows/merge-docker-chronicle.yaml
+++ b/.github/workflows/merge-docker-chronicle.yaml
@@ -28,7 +28,7 @@ jobs:
       commit_hash8: ${{ steps.get-sha.outputs.sha8 }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get SHA
         id: get-sha
         run: |
@@ -50,7 +50,7 @@ jobs:
             profile: testnet
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create target dir
         run: mkdir -p ${{ github.workspace }}/target/${{ matrix.profile }}
       - name: Cache Rust deps

--- a/.github/workflows/merge-docker-tester.yaml
+++ b/.github/workflows/merge-docker-tester.yaml
@@ -27,7 +27,7 @@ jobs:
       commit_hash8: ${{ steps.get-sha.outputs.sha8 }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get SHA
         id: get-sha
         run: |
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Cargo

--- a/.github/workflows/merge-docker-timenode.yaml
+++ b/.github/workflows/merge-docker-timenode.yaml
@@ -17,7 +17,7 @@ jobs:
       commit_hash8: ${{ steps.get-sha.outputs.sha8 }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get SHA
         id: get-sha
         run: |
@@ -44,7 +44,7 @@ jobs:
             features: development
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create target dir
         run: mkdir -p ${{ github.workspace }}/target/${{ matrix.profile }}
       - name: Cache Rust deps

--- a/.github/workflows/merge-srtool-runtime.yaml
+++ b/.github/workflows/merge-srtool-runtime.yaml
@@ -12,7 +12,7 @@ jobs:
       commit_hash8: ${{ steps.get-sha.outputs.sha8 }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get SHA
         id: get-sha
         run: |
@@ -43,7 +43,7 @@ jobs:
             features: development
     steps:
       - name: Fetch latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build timechain runtime
         id: srtool_build
         uses: chevdor/srtool-actions@v0.8.0

--- a/.github/workflows/pr-optional-benchmarks.yaml
+++ b/.github/workflows/pr-optional-benchmarks.yaml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name,'!ci-benchmark') }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Build runtime benchmarks
@@ -54,7 +54,7 @@ jobs:
     runs-on: [self-hosted, benchmark]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           submodules: recursive

--- a/.github/workflows/pr-optional-compose.yaml
+++ b/.github/workflows/pr-optional-compose.yaml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name,'!ci-test-basic') }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Configure sccache env for Rust


### PR DESCRIPTION
## Description

Bump the version of GitHub's `checkout` action to `v4` all the remaining `v3` to remove deprecation various warnings during CI runs.