### PR TITLE
connector: update to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5660,7 +5660,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5754,7 +5754,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -10672,7 +10672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
- "rand 0.8.5",
+ "rand 0.7.3",
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
@@ -12627,7 +12627,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "log",
  "multimap 0.10.0",
  "once_cell",
@@ -12660,7 +12660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.75",
@@ -13509,7 +13509,7 @@ dependencies = [
 [[package]]
 name = "rosetta-client"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13538,7 +13538,7 @@ dependencies = [
 [[package]]
 name = "rosetta-config-astar"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "anyhow",
  "rosetta-core",
@@ -13548,7 +13548,7 @@ dependencies = [
 [[package]]
 name = "rosetta-config-ethereum"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "anyhow",
  "const-hex",
@@ -13568,7 +13568,7 @@ dependencies = [
 [[package]]
 name = "rosetta-config-polkadot"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "anyhow",
  "rosetta-core",
@@ -13579,7 +13579,7 @@ dependencies = [
 [[package]]
 name = "rosetta-core"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13596,7 +13596,7 @@ dependencies = [
 [[package]]
 name = "rosetta-crypto"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "anyhow",
  "bech32",
@@ -13622,7 +13622,7 @@ dependencies = [
 [[package]]
 name = "rosetta-ethereum-backend"
 version = "0.1.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -13638,7 +13638,7 @@ dependencies = [
 [[package]]
 name = "rosetta-ethereum-types"
 version = "0.2.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "bytes",
  "const-hex",
@@ -13672,7 +13672,7 @@ dependencies = [
 [[package]]
 name = "rosetta-server"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13695,7 +13695,7 @@ dependencies = [
 [[package]]
 name = "rosetta-server-astar"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13719,10 +13719,11 @@ dependencies = [
 [[package]]
 name = "rosetta-server-ethereum"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "anyhow",
  "async-trait",
+ "auto_impl",
  "fork-tree 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer",
  "futures-util",
@@ -13747,7 +13748,7 @@ dependencies = [
 [[package]]
 name = "rosetta-server-polkadot"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13768,7 +13769,7 @@ dependencies = [
 [[package]]
 name = "rosetta-tx-ethereum"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "anyhow",
  "rosetta-config-ethereum",
@@ -13779,7 +13780,7 @@ dependencies = [
 [[package]]
 name = "rosetta-tx-polkadot"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "anyhow",
  "blake2-rfc",
@@ -13793,7 +13794,7 @@ dependencies = [
 [[package]]
 name = "rosetta-types"
 version = "0.6.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "serde",
  "serde_json",
@@ -13802,7 +13803,7 @@ dependencies = [
 [[package]]
 name = "rosetta-utils"
 version = "0.1.0"
-source = "git+https://github.com/analog-labs/chain-connectors#ddb58a6c6bd117e21c164145503cbf57e1f9dbb0"
+source = "git+https://github.com/analog-labs/chain-connectors#f472ac3a546047390a913515315c973b39302ae7"
 dependencies = [
  "bytes",
  "futures-timer",
@@ -19720,7 +19721,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 


### PR DESCRIPTION
## Description

Guess nobody actually though of updating the connector here as well, so this PR fixes that.

Contains the following changes, see [Changelog](https://github.com/Analog-Labs/chain-connectors/compare/ddb58a6...f472ac3):
- Analog-Labs/chain-connectors#246
- Analog-Labs/chain-connectors#254
- Analog-Labs/chain-connectors#243

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update