### PR TITLE
ci: build chronicles on ci binary branches

### DIFF
--- a/.github/workflows/merge-docker-chronicle.yaml
+++ b/.github/workflows/merge-docker-chronicle.yaml
@@ -13,6 +13,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
     branches:
+      - "ci/binary/**"
       - 'development'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description

Minor fix that ensures that chronicles are also build on `ci/binary/...` release branches, just like timenode build are.