### PR TITLE
Adds negative case test for task assignment for registered shard

### DIFF
--- a/pallets/tasks/src/tests.rs
+++ b/pallets/tasks/src/tests.rs
@@ -639,6 +639,7 @@ fn task_unassigned_for_unregister_shard() {
 			vec![task_id]
 		);
 		register_gateway(shard_id);
+		roll(1);
 		assert_eq!(UnassignedTasks::<Test>::iter().collect::<Vec<_>>().len(), 0);
 	});
 }


### PR DESCRIPTION
## Description

New implementation for task assignment only works when a shard is registered. 
Test case for negative flow for that task assignment was missing which i added.

Fixes # (issue)
https://github.com/Analog-Labs/timechain/issues/1132

## Tests

- [x] task_unassigned_for_unregister_shard

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] I have made corresponding changes to the documentation
- [x] Code changes introduces no new problems or warnings
- [x] Test cases have been added 
- [x] Dependent changes have been merged and published in downstream modules