### PR TITLE
Remove sign task.

### DIFF
--- a/chronicle/src/mock.rs
+++ b/chronicle/src/mock.rs
@@ -9,7 +9,7 @@ use time_primitives::traits::IdentifyAccount;
 use time_primitives::{
 	sr25519, AccountId, Balance, BatchId, BlockHash, BlockNumber, ChainName, ChainNetwork,
 	Commitment, Gateway, GatewayMessage, MemberStatus, NetworkId, PeerId, ProofOfKnowledge,
-	PublicKey, ShardId, ShardStatus, Task, TaskId, TaskResult, TssSignature,
+	PublicKey, ShardId, ShardStatus, Task, TaskId, TaskResult,
 };
 use tokio::time::Duration;
 use tss::{sum_commitments, VerifiableSecretSharingCommitment, VerifyingKey};
@@ -64,7 +64,6 @@ impl MockTask {
 
 pub struct MockBatch {
 	pub message: GatewayMessage,
-	pub signature: Option<TssSignature>,
 }
 
 type Map<K, V> = Arc<Mutex<HashMap<K, V>>>;
@@ -286,11 +285,6 @@ impl Runtime for Mock {
 	async fn get_task_submitter(&self, task_id: TaskId) -> Result<Option<PublicKey>> {
 		let tasks = self.tasks.lock().unwrap();
 		Ok(tasks.get(&task_id).unwrap().submitter.clone())
-	}
-
-	async fn get_batch_signature(&self, batch: BatchId) -> Result<Option<TssSignature>> {
-		let batches = self.batches.lock().unwrap();
-		Ok(batches.get(&batch).unwrap().signature)
 	}
 
 	async fn get_batch_message(&self, batch: BatchId) -> Result<Option<GatewayMessage>> {

--- a/chronicle/src/runtime.rs
+++ b/chronicle/src/runtime.rs
@@ -5,7 +5,7 @@ use tc_subxt::SubxtClient;
 use time_primitives::{
 	AccountId, Balance, BatchId, BlockHash, BlockNumber, ChainName, ChainNetwork, Commitment,
 	Gateway, GatewayMessage, MemberStatus, NetworkId, PeerId, ProofOfKnowledge, PublicKey, ShardId,
-	ShardStatus, Task, TaskId, TaskResult, TssSignature,
+	ShardStatus, Task, TaskId, TaskResult,
 };
 
 #[async_trait]
@@ -45,8 +45,6 @@ pub trait Runtime: Clone + Send + Sync + 'static {
 	async fn get_task_submitter(&self, task_id: TaskId) -> Result<Option<PublicKey>>;
 
 	async fn get_batch_message(&self, batch_id: BatchId) -> Result<Option<GatewayMessage>>;
-
-	async fn get_batch_signature(&self, batch_id: BatchId) -> Result<Option<TssSignature>>;
 
 	async fn get_gateway(&self, network: NetworkId) -> Result<Option<Gateway>>;
 
@@ -145,10 +143,6 @@ impl Runtime for SubxtClient {
 
 	async fn get_task_submitter(&self, task_id: TaskId) -> Result<Option<PublicKey>> {
 		self.task_submitter(task_id).await
-	}
-
-	async fn get_batch_signature(&self, batch: BatchId) -> Result<Option<TssSignature>> {
-		self.batch_signature(batch).await
 	}
 
 	async fn get_gateway(&self, network: NetworkId) -> Result<Option<Gateway>> {

--- a/chronicle/src/tasks/mod.rs
+++ b/chronicle/src/tasks/mod.rs
@@ -114,26 +114,16 @@ where
 				let signature = self.tss_sign(block_number, shard_id, task_id, payload).await?;
 				Some(TaskResult::ReadGatewayEvents { events, signature })
 			},
-			Task::SignGatewayMessage { batch_id } => {
+			Task::SubmitGatewayMessage { batch_id } => {
 				let msg =
 					self.runtime.get_batch_message(batch_id).await?.context("invalid task")?;
 				let payload = GmpParams::new(network_id, gateway).hash(&msg.encode(batch_id));
 				let signature =
 					self.tss_sign(block_number, shard_id, task_id, payload.to_vec()).await?;
-				Some(TaskResult::SignGatewayMessage { signature })
-			},
-			Task::SubmitGatewayMessage { batch_id } => {
-				let msg =
-					self.runtime.get_batch_message(batch_id).await?.context("missing message")?;
-				let sig = self
-					.runtime
-					.get_batch_signature(batch_id)
-					.await?
-					.context("missing signature")?;
 				let signer =
 					self.runtime.get_shard_commitment(shard_id).await?.context("invalid shard")?[0];
 				if let Err(error) =
-					self.connector.submit_commands(gateway, batch_id, msg, signer, sig).await
+					self.connector.submit_commands(gateway, batch_id, msg, signer, signature).await
 				{
 					Some(TaskResult::SubmitGatewayMessage { error })
 				} else {

--- a/pallets/tasks/src/lib.rs
+++ b/pallets/tasks/src/lib.rs
@@ -68,8 +68,8 @@ pub mod pallet {
 	use sp_std::vec::Vec;
 
 	use time_primitives::{
-		AccountId, Balance, BatchBuilder, BatchId, GatewayMessage, GatewayOp, GmpEvent, GmpParams,
-		MessageId, NetworkId, NetworksInterface, PublicKey, ShardId, ShardsInterface, Task, TaskId,
+		AccountId, Balance, BatchBuilder, BatchId, GatewayMessage, GatewayOp, GmpEvent, MessageId,
+		NetworkId, NetworksInterface, PublicKey, ShardId, ShardsInterface, Task, TaskId,
 		TaskResult, TasksInterface, TssPublicKey, TssSignature,
 	};
 
@@ -231,18 +231,8 @@ pub mod pallet {
 	pub type BatchMessage<T: Config> =
 		StorageMap<_, Blake2_128Concat, BatchId, GatewayMessage, OptionQuery>;
 
-	/// Map storage for batch signatures
 	#[pallet::storage]
-	pub type BatchSignature<T: Config> =
-		StorageMap<_, Blake2_128Concat, BatchId, TssSignature, OptionQuery>;
-
-	#[pallet::storage]
-	pub type BatchSignTaskId<T: Config> =
-		StorageMap<_, Blake2_128Concat, BatchId, TaskId, OptionQuery>;
-
-	#[pallet::storage]
-	pub type BatchSubmissionTaskId<T: Config> =
-		StorageMap<_, Blake2_128Concat, BatchId, TaskId, OptionQuery>;
+	pub type BatchTaskId<T: Config> = StorageMap<_, Blake2_128Concat, BatchId, TaskId, OptionQuery>;
 
 	/// Map storage for task signers.
 	#[pallet::storage]
@@ -314,9 +304,8 @@ pub mod pallet {
 			}
 			let shard = TaskShard::<T>::get(task_id).ok_or(Error::<T>::UnassignedTask)?;
 			let network = T::Shards::shard_network(shard).ok_or(Error::<T>::UnknownShard)?;
-			let gateway = T::Networks::gateway(network).ok_or(Error::<T>::GatewayNotRegistered)?;
 			let reward = task.reward();
-			match (task, result) {
+			let result = match (task, result) {
 				(
 					Task::ReadGatewayEvents { blocks },
 					TaskResult::ReadGatewayEvents { events, signature },
@@ -349,47 +338,26 @@ pub mod pallet {
 								Self::deposit_event(Event::<T>::MessageExecuted(msg_id));
 							},
 							GmpEvent::BatchExecuted(batch_id) => {
-								if let Some(task_id) = BatchSubmissionTaskId::<T>::get(batch_id) {
+								if let Some(task_id) = BatchTaskId::<T>::get(batch_id) {
 									Self::finish_task(network, task_id, Ok(()));
 								}
 							},
 						}
 					}
-					// complete task
-					Self::treasury_transfer_shard(shard, reward);
-					Self::finish_task(network, task_id, Ok(()));
-				},
-				(
-					Task::SignGatewayMessage { batch_id },
-					TaskResult::SignGatewayMessage { signature },
-				) => {
-					// verify signature
-					let msg = BatchMessage::<T>::get(batch_id).ok_or(Error::<T>::InvalidBatchId)?;
-					let payload = msg.encode(batch_id);
-					let params = GmpParams { network, gateway };
-					let bytes = params.hash(&payload);
-					Self::verify_signature(shard, &bytes, signature)?;
-					// store signature
-					BatchSignature::<T>::insert(batch_id, signature);
-					// start submission
-					let submission_task_id =
-						Self::create_task(network, Task::SubmitGatewayMessage { batch_id });
-					BatchSubmissionTaskId::<T>::insert(batch_id, submission_task_id);
-					// complete task
-					Self::treasury_transfer_shard(shard, reward);
-					Self::finish_task(network, task_id, Ok(()));
+					Ok(())
 				},
 				(Task::SubmitGatewayMessage { .. }, TaskResult::SubmitGatewayMessage { error }) => {
 					// verify signature
 					let expected_signer =
 						TaskSubmitter::<T>::get(task_id).map(|s| s.into_account());
 					ensure!(Some(&signer) == expected_signer.as_ref(), Error::<T>::InvalidSigner);
-					// complete task
-					Self::treasury_transfer(signer, reward);
-					Self::finish_task(network, task_id, Err(error));
+					Err(error)
 				},
 				(_, _) => return Err(Error::<T>::InvalidTaskResult.into()),
 			};
+			// complete task
+			Self::treasury_transfer_shard(shard, reward);
+			Self::finish_task(network, task_id, result);
 			Ok(())
 		}
 	}
@@ -614,8 +582,8 @@ pub mod pallet {
 				}
 			}
 			BatchMessage::<T>::insert(batch_id, msg);
-			let task_id = Self::create_task(network, Task::SignGatewayMessage { batch_id });
-			BatchSignTaskId::<T>::insert(batch_id, task_id);
+			let task_id = Self::create_task(network, Task::SubmitGatewayMessage { batch_id });
+			BatchTaskId::<T>::insert(batch_id, task_id);
 		}
 	}
 
@@ -652,10 +620,6 @@ pub mod pallet {
 
 		pub fn get_batch_message(batch: BatchId) -> Option<GatewayMessage> {
 			BatchMessage::<T>::get(batch)
-		}
-
-		pub fn get_batch_signature(batch: BatchId) -> Option<TssSignature> {
-			BatchSignature::<T>::get(batch)
 		}
 	}
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -117,7 +117,6 @@ sp_api::decl_runtime_apis! {
 		fn get_task_submitter(task_id: TaskId) -> Option<PublicKey>;
 		fn get_task_result(task_id: TaskId) -> Option<Result<(), String>>;
 		fn get_batch_message(batch_id: BatchId) -> Option<GatewayMessage>;
-		fn get_batch_signature(batch_id: BatchId) -> Option<TssSignature>;
 	}
 
 	pub trait SubmitTransactionApi{

--- a/primitives/src/task.rs
+++ b/primitives/src/task.rs
@@ -11,7 +11,6 @@ pub type TaskId = u64;
 #[derive(Debug, Clone, Decode, Encode, TypeInfo, PartialEq)]
 pub enum Task {
 	ReadGatewayEvents { blocks: Range<u64> },
-	SignGatewayMessage { batch_id: BatchId },
 	SubmitGatewayMessage { batch_id: BatchId },
 }
 
@@ -23,9 +22,6 @@ impl std::fmt::Display for Task {
 				let start = blocks.start;
 				let end = blocks.end;
 				write!(f, "ReadGatewayEvents({start}..{end})")
-			},
-			Self::SignGatewayMessage { batch_id } => {
-				write!(f, "SignPayload({batch_id})")
 			},
 			Self::SubmitGatewayMessage { batch_id } => {
 				write!(f, "SubmitGatewayMessage({batch_id})")
@@ -69,10 +65,6 @@ pub fn encode_gmp_events(task_id: TaskId, events: &[GmpEvent]) -> Vec<u8> {
 pub enum TaskResult {
 	ReadGatewayEvents {
 		events: Vec<GmpEvent>,
-		#[cfg_attr(feature = "std", serde(with = "crate::shard::serde_tss_signature"))]
-		signature: TssSignature,
-	},
-	SignGatewayMessage {
 		#[cfg_attr(feature = "std", serde(with = "crate::shard::serde_tss_signature"))]
 		signature: TssSignature,
 	},

--- a/runtimes/mainnet/src/lib.rs
+++ b/runtimes/mainnet/src/lib.rs
@@ -1848,10 +1848,6 @@ impl_runtime_apis! {
 		fn get_batch_message(batch_id: BatchId) -> Option<GatewayMessage> {
 			Tasks::get_batch_message(batch_id)
 		}
-
-		fn get_batch_signature(batch_id: BatchId) -> Option<TssSignature> {
-			Tasks::get_batch_signature(batch_id)
-		}
 	}
 
 	impl time_primitives::SubmitTransactionApi<Block> for Runtime {

--- a/runtimes/testnet/src/lib.rs
+++ b/runtimes/testnet/src/lib.rs
@@ -1478,10 +1478,6 @@ impl_runtime_apis! {
 		fn get_batch_message(batch_id: BatchId) -> Option<GatewayMessage> {
 			Tasks::get_batch_message(batch_id)
 		}
-
-		fn get_batch_signature(batch_id: BatchId) -> Option<TssSignature> {
-			Tasks::get_batch_signature(batch_id)
-		}
 	}
 
 	impl time_primitives::SubmitTransactionApi<Block> for Runtime {

--- a/tc-cli/src/main.rs
+++ b/tc-cli/src/main.rs
@@ -352,9 +352,7 @@ impl IntoRow for Task {
 #[derive(Tabled)]
 struct BatchEntry {
 	batch: BatchId,
-	sign: TaskId,
-	sig: String,
-	submit: String,
+	task: TaskId,
 }
 
 impl IntoRow for Batch {
@@ -363,9 +361,7 @@ impl IntoRow for Batch {
 	fn into_row(self, _tc: &Tc) -> Result<Self::Row> {
 		Ok(BatchEntry {
 			batch: self.batch,
-			sign: self.sign,
-			sig: self.sig.map(hex::encode).unwrap_or_default(),
-			submit: self.submit.map(|t| t.to_string()).unwrap_or_default(),
+			task: self.task,
 		})
 	}
 }
@@ -410,7 +406,6 @@ struct MessageTraceEntry {
 	src_sync: String,
 	dest_sync: String,
 	recv: String,
-	sign: String,
 	submit: String,
 	exec: String,
 }
@@ -441,7 +436,6 @@ impl IntoRow for MessageTrace {
 				"- / -".into()
 			},
 			recv: self.recv.map(task_to_string).unwrap_or_default(),
-			sign: self.sign.map(task_to_string).unwrap_or_default(),
 			submit: self.submit.map(task_to_string).unwrap_or_default(),
 			exec: self.exec.map(task_to_string).unwrap_or_default(),
 		})

--- a/tc-subxt/src/api/tasks.rs
+++ b/tc-subxt/src/api/tasks.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use futures::channel::oneshot;
 use time_primitives::{
 	BatchId, GatewayMessage, MessageId, NetworkId, PublicKey, ShardId, Task, TaskId, TaskResult,
-	TssSignature,
 };
 
 impl SubxtClient {
@@ -87,23 +86,9 @@ impl SubxtClient {
 		})
 	}
 
-	pub async fn batch_signature(&self, batch: BatchId) -> Result<Option<TssSignature>> {
+	pub async fn batch_task(&self, batch: BatchId) -> Result<Option<TaskId>> {
 		metadata_scope!(self.metadata, {
-			let runtime_call = metadata::apis().tasks_api().get_batch_signature(batch);
-			Ok(self.client.runtime_api().at_latest().await?.call(runtime_call).await?)
-		})
-	}
-
-	pub async fn batch_sign_task(&self, batch: BatchId) -> Result<Option<TaskId>> {
-		metadata_scope!(self.metadata, {
-			let storage_query = metadata::storage().tasks().batch_sign_task_id(batch);
-			Ok(self.client.storage().at_latest().await?.fetch(&storage_query).await?)
-		})
-	}
-
-	pub async fn batch_submission_task(&self, batch: BatchId) -> Result<Option<TaskId>> {
-		metadata_scope!(self.metadata, {
-			let storage_query = metadata::storage().tasks().batch_submission_task_id(batch);
+			let storage_query = metadata::storage().tasks().batch_task_id(batch);
 			Ok(self.client.storage().at_latest().await?.fetch(&storage_query).await?)
 		})
 	}


### PR DESCRIPTION
Removes the sign/submit task split. This can cause issues when a shard goes offline and the submit task is reassigned. The signature will no longer be valid. This way we can keep a simple task scheduler and there doesn't seem to be much advantage to having separate tasks for this.