### PR TITLE
Remove unused enum SerializedMemberStatus

### DIFF
--- a/primitives/src/shard.rs
+++ b/primitives/src/shard.rs
@@ -9,7 +9,6 @@ use futures::channel::oneshot;
 use serde::{Deserialize, Serialize};
 
 use scale_codec::{Decode, Encode};
-use scale_info::prelude::string::String;
 use scale_info::prelude::vec::Vec;
 use scale_info::TypeInfo;
 
@@ -96,14 +95,6 @@ impl std::fmt::Display for MemberStatus {
 		};
 		f.write_str(status)
 	}
-}
-
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode, TypeInfo)]
-pub enum SerializedMemberStatus {
-	Added,
-	Committed(Vec<String>),
-	Ready,
 }
 
 /// Track status of shard


### PR DESCRIPTION
Removes unused enum in shard primitives