### PR TITLE
Fix CI failure related to MaxTasksPerBlock set too high

### DIFF
--- a/runtimes/mainnet/src/lib.rs
+++ b/runtimes/mainnet/src/lib.rs
@@ -1400,7 +1400,7 @@ impl pallet_tasks::Config for Runtime {
 	type WeightInfo = weights::tasks::WeightInfo<Runtime>;
 	type Networks = Networks;
 	type Shards = Shards;
-	type MaxTasksPerBlock = ConstU32<1_500>;
+	type MaxTasksPerBlock = ConstU32<500>;
 	type MaxBatchesPerBlock = ConstU32<1_000>;
 }
 

--- a/runtimes/testnet/src/lib.rs
+++ b/runtimes/testnet/src/lib.rs
@@ -1004,7 +1004,7 @@ impl pallet_tasks::Config for Runtime {
 	type WeightInfo = weights::tasks::WeightInfo<Runtime>;
 	type Networks = Networks;
 	type Shards = Shards;
-	type MaxTasksPerBlock = ConstU32<1_500>;
+	type MaxTasksPerBlock = ConstU32<500>;
 	type MaxBatchesPerBlock = ConstU32<1_000>;
 }
 


### PR DESCRIPTION
Fixes CI failure on a few open PRs which isn't related to the changes made in those PRs

I am not really sure how this test failure was introduced because the test was run before merging #1186 and that is the PR where the test is last adjusted.