### PR TITLE
block gas limit gmp-api

### DIFF
--- a/gmp/evm/src/lib.rs
+++ b/gmp/evm/src/lib.rs
@@ -8,7 +8,7 @@ use rosetta_client::{
 	query::GetLogs, types::AccountIdentifier, AtBlock, CallResult, FilterBlockOption,
 	GetTransactionCount, SubmitResult, TransactionReceipt, Wallet,
 };
-use rosetta_ethereum_backend::jsonrpsee::Adapter;
+use rosetta_ethereum_backend::{jsonrpsee::Adapter, EthereumRpc};
 use rosetta_server::ws::{default_client, DefaultClient};
 use rosetta_server_ethereum::utils::{
 	DefaultFeeEstimatorConfig, EthereumRpcExt, PolygonFeeEstimatorConfig,
@@ -419,5 +419,15 @@ impl IConnectorAdmin for Connector {
 		};
 		Ok(u128::try_from(fee_estimator.0)
 			.map_err(|_| anyhow::anyhow!("Failed to convert value from U256 to u128"))?)
+	}
+
+	/// Returns gas limit of latest block.
+	async fn block_gas_limit(&self) -> Result<u64> {
+		let block = self
+			.backend
+			.block(AtBlock::Latest)
+			.await?
+			.with_context(|| "Cannot find latest block")?;
+		Ok(block.header.gas_limit)
 	}
 }

--- a/gmp/grpc/build.rs
+++ b/gmp/grpc/build.rs
@@ -32,6 +32,7 @@ fn main() {
 		.method(method("send_message", "SendMessage").build())
 		.method(method("recv_messages", "RecvMessages").build())
 		.method(method("transaction_base_fee", "TransactionBaseFee").build())
+		.method(method("block_gas_limit", "BlockGasLimit").build())
 		.build();
 	Builder::new().compile(&[service]);
 }

--- a/gmp/grpc/src/lib.rs
+++ b/gmp/grpc/src/lib.rs
@@ -276,4 +276,11 @@ impl IConnectorAdmin for Connector {
 		let response = self.client.lock().await.transaction_base_fee(request).await?.into_inner();
 		Ok(response.base_fee)
 	}
+
+	/// Returns gas limit of latest block.
+	async fn block_gas_limit(&self) -> Result<u64> {
+		let request = Request::new(proto::BlockGasLimitRequest {});
+		let response = self.client.lock().await.block_gas_limit(request).await?.into_inner();
+		Ok(response.gas_limit)
+	}
 }

--- a/gmp/grpc/src/main.rs
+++ b/gmp/grpc/src/main.rs
@@ -274,6 +274,18 @@ impl Gmp for ConnectorWrapper {
 			.map_err(|err| Status::unknown(err.to_string()))?;
 		Ok(Response::new(proto::TransactionBaseFeeResponse { base_fee }))
 	}
+
+	async fn block_gas_limit(
+		&self,
+		request: Request<proto::BlockGasLimitRequest>,
+	) -> GmpResult<proto::BlockGasLimitResponse> {
+		let (connector, _) = self.connector(request)?;
+		let gas_limit = connector
+			.block_gas_limit()
+			.await
+			.map_err(|err| Status::unknown(err.to_string()))?;
+		Ok(Response::new(proto::BlockGasLimitResponse { gas_limit }))
+	}
 }
 
 #[derive(Parser)]

--- a/gmp/grpc/src/proto.rs
+++ b/gmp/grpc/src/proto.rs
@@ -194,3 +194,11 @@ pub struct TransactionBaseFeeRequest {}
 pub struct TransactionBaseFeeResponse {
 	pub base_fee: u128,
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct BlockGasLimitRequest {}
+
+#[derive(Serialize, Deserialize)]
+pub struct BlockGasLimitResponse {
+	pub gas_limit: u64,
+}

--- a/gmp/rust/src/lib.rs
+++ b/gmp/rust/src/lib.rs
@@ -462,6 +462,11 @@ impl IConnectorAdmin for Connector {
 	async fn transaction_base_fee(&self) -> Result<u128> {
 		Ok(0)
 	}
+
+	/// Returns gas limit of latest block.
+	async fn block_gas_limit(&self) -> Result<u64> {
+		Ok(0)
+	}
 }
 
 #[derive(Debug)]

--- a/primitives/src/gmp.rs
+++ b/primitives/src/gmp.rs
@@ -370,6 +370,8 @@ pub trait IConnectorAdmin: IConnector {
 		-> Result<Vec<GmpMessage>>;
 	/// Calculate transaction base fee for a chain.
 	async fn transaction_base_fee(&self) -> Result<u128>;
+	/// Calculate returns the latest block gas_limit for a chain.
+	async fn block_gas_limit(&self) -> Result<u64>;
 }
 
 #[cfg(feature = "std")]

--- a/tc-cli/src/lib.rs
+++ b/tc-cli/src/lib.rs
@@ -517,6 +517,15 @@ impl Tc {
 		Ok(base_fee)
 	}
 
+	pub async fn block_gas_limit(&self, network: NetworkId) -> Result<u64> {
+		let connector = self
+			.connectors
+			.get(&network)
+			.with_context(|| format!("Connector for network id: {:?} not found", network))?;
+		let gas_limit = connector.block_gas_limit().await?;
+		Ok(gas_limit)
+	}
+
 	pub async fn batch(&self, batch: BatchId) -> Result<Batch> {
 		Ok(Batch {
 			batch,

--- a/tc-cli/src/main.rs
+++ b/tc-cli/src/main.rs
@@ -102,6 +102,9 @@ enum Command {
 	Batch {
 		batch: BatchId,
 	},
+	BlockGasLimit {
+		network: NetworkId,
+	},
 	Message {
 		message: String,
 	},
@@ -544,6 +547,11 @@ async fn real_main() -> Result<()> {
 			let ops = std::mem::take(&mut batch.msg.ops);
 			print_table(&tc, vec![batch])?;
 			print_table(&tc, ops)?;
+		},
+
+		Command::BlockGasLimit { network } => {
+			let base_fee = tc.block_gas_limit(network).await?;
+			println!("Gas limit for block: {} is : {}", network, base_fee);
 		},
 		Command::Message { message } => {
 			let message = hex::decode(message)?


### PR DESCRIPTION
## Description

Part of https://github.com/Analog-Labs/timechain/issues/1236 which prints out the block's gas limit so we can set a proper ration in config.yaml for the network's batch gas limit. The Process is partial manual right now.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Inline comments have been added for each method
- [x] I have made corresponding changes to the documentation
- [x] Code changes introduces no new problems or warnings
- [x] Dependent changes have been merged and published in downstream modules