### PR TITLE
ci: add missing tc-cli rust-src component

### DIFF
--- a/.github/workflows/merge-docker-tc-cli.yaml
+++ b/.github/workflows/merge-docker-tc-cli.yaml
@@ -49,6 +49,7 @@ jobs:
         with:
           toolchain: stable
           target: x86_64-unknown-linux-musl,wasm32-unknown-unknown
+          components: rust-src
       - name: Install musl deps
         run: sudo apt-get update && sudo apt-get install -y musl-tools
       - name: Rust cache


### PR DESCRIPTION
## Description

`tc-cli` docker build is failing because of missing `rust-src` component