### PR TITLE
ci: move tc-cli docker build to self-hosted

### DIFF
--- a/.github/workflows/merge-docker-tc-cli.yaml
+++ b/.github/workflows/merge-docker-tc-cli.yaml
@@ -38,7 +38,7 @@ jobs:
   build-binary:
     name: Build Docker image
     needs: ["set-tags"]
-    runs-on: ubuntu-latest
+    runs-on: ["self-hosted", "container"]
     steps:
       - name: Fetch latest code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

The GH runner experiences storage issues, so this PR moves the build to the self hosted node.