### PR TITLE
ci: runtime upgrade trigger

### DIFF
--- a/.github/workflows/merge-srtool-runtime.yaml
+++ b/.github/workflows/merge-srtool-runtime.yaml
@@ -69,6 +69,7 @@ jobs:
             timechain-srtool-digest.json
   upgrade-runtime:
     name: Runtime upgrade
+    # Only running when manually triggered
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
@@ -77,9 +78,12 @@ jobs:
     - name: Download runtime benchmarks
       uses: actions/download-artifact@v4
       with:
+        # NOTE: the assumption is that it will only deploy on development envs
+        # Later we can add an input to specify what the target should be
         name: development-runtime
     - name: Extract runtime
       run: |
+        # The artifact is also named development-runtime
         unzip development-runtime.zip
         WASM_PATH=$(find runtime/* -type f -name "*.wasm")
         docker run -it --rm \


### PR DESCRIPTION
## Description

This PR extends the srtool runtime build to have a manual dispatch an trigger a runtime upgrade.

**NOTE**: once it merges I can test and add the proper environments, currently it's fixed to development 