### PR TITLE
ci: fix runtime upgrade CI

### DIFF
--- a/.github/workflows/merge-srtool-runtime.yaml
+++ b/.github/workflows/merge-srtool-runtime.yaml
@@ -1,4 +1,15 @@
-name: Build runtime artifacts
+# Runtime WASM build & upgrade
+#
+# Triggers:
+# 1. branch with 'ci/runtime' prefix
+#    This trigger only does the srtool build without deployment.
+#    The WASM blobs are attached in the build artifacts.
+# 2. manual trigger (workflow_dispatch)
+#    This trigger both builds and does a runtime upgrade on the selected
+#    environment.
+#    **NOTE**: there are no additional checks if the runtime can be applied
+
+name: Runtime build/upgrade
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Description

This PR fixes the runtime upgrade CI for applying the upgrade to the timechain.

It adds a manual trigger (`workflow_dispatch`) to select the target environment to apply the runtime upgrade. 
**NOTE**: The CI doesn't do any additional checks if the runtime can be applied, so the chain should be monitored. This will be changed with fix for #1270 