### PR TITLE
Optimize members::on_initialize to increase MaxHeartbeatTimeoutsPerBlock

### DIFF
--- a/pallets/members/src/benchmarking.rs
+++ b/pallets/members/src/benchmarking.rs
@@ -1,12 +1,12 @@
 use super::*;
-use crate::Pallet;
+use crate::{Config, Pallet};
 
 use polkadot_sdk::*;
 
 use frame_benchmarking::benchmarks;
 use frame_support::traits::{Currency, Get};
 use frame_system::RawOrigin;
-use time_primitives::{traits::IdentifyAccount, AccountId, NetworkId, PublicKey};
+use time_primitives::{traits::IdentifyAccount, AccountId, MembersInterface, NetworkId, PublicKey};
 
 pub const ALICE: [u8; 32] = [1u8; 32];
 pub const ETHEREUM: NetworkId = 1;
@@ -60,15 +60,15 @@ benchmarks! {
 			);
 			Pallet::<T>::register_member(RawOrigin::Signed(caller.clone()).into(), ETHEREUM, pk_from_account(raw), caller.clone().into(), <T as Config>::MinStake::get())?;
 			Pallet::<T>::send_heartbeat(RawOrigin::Signed(caller.clone()).into())?;
-			assert!(MemberOnline::<T>::get(&caller).is_some());
-			assert!(Heartbeat::<T>::take(&caller).is_some());
+			assert!(Pallet::<T>::is_member_online(&caller));
 		}
+		frame_system::Pallet::<T>::set_block_number(T::HeartbeatTimeout::get() + T::HeartbeatTimeout::get());
 	}: {
 		Pallet::<T>::timeout_heartbeats();
 	} verify {
 		for i in 0..b {
 			let caller: AccountId = [i as u8; 32].into();
-			assert!(MemberOnline::<T>::get(&caller).is_none());
+			assert!(!Pallet::<T>::is_member_online(&caller));
 		}
 	}
 

--- a/pallets/members/src/tests.rs
+++ b/pallets/members/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::mock::*;
-use crate::{Error, Event, Heartbeat, MemberNetwork, MemberOnline, MemberPeerId, MemberStake};
+use crate::{Error, Event, MemberNetwork, MemberPeerId, MemberStake, Pallet};
 
 use polkadot_sdk::{frame_support, frame_system, sp_runtime};
 
@@ -91,8 +91,7 @@ fn send_heartbeat_works() {
 		assert_ok!(send_heartbeat(A));
 		assert_ok!(send_heartbeat(A));
 		System::assert_last_event(Event::<Test>::HeartbeatReceived(a.clone()).into());
-		assert!(MemberOnline::<Test>::get(&a).is_some());
-		assert!(Heartbeat::<Test>::get(&a).is_some());
+		assert!(Pallet::<Test>::is_member_online(&a));
 	});
 }
 
@@ -103,9 +102,9 @@ fn no_heartbeat_sets_member_offline_after_timeout() {
 		assert_ok!(register_member(a.clone(), A, 5));
 		assert_ok!(send_heartbeat(A));
 		roll_to(10);
-		assert!(MemberOnline::<Test>::get(&a).is_some());
+		assert!(Pallet::<Test>::is_member_online(&a));
 		roll_to(20);
-		assert!(MemberOnline::<Test>::get(&a).is_none());
+		assert!(!Pallet::<Test>::is_member_online(&a));
 	});
 }
 
@@ -115,10 +114,9 @@ fn send_heartbeat_sets_member_back_online_after_timeout() {
 		let a: AccountId = A.into();
 		assert_ok!(register_member(a.clone(), A, 5));
 		roll_to(20);
-		assert!(MemberOnline::<Test>::get(&a).is_none());
+		assert!(!Pallet::<Test>::is_member_online(&a));
 		assert_ok!(send_heartbeat(A));
-		assert!(MemberOnline::<Test>::get(&a).is_some());
-		assert!(Heartbeat::<Test>::get(&a).is_some());
+		assert!(Pallet::<Test>::is_member_online(&a));
 	});
 }
 
@@ -159,6 +157,5 @@ fn unregister_member_works() {
 		assert_eq!(Balances::free_balance(&a), 10000000000);
 		assert_eq!(MemberPeerId::<Test>::get(&a), None);
 		assert_eq!(MemberNetwork::<Test>::get(&a), None);
-		assert!(Heartbeat::<Test>::get(&a).is_none());
 	});
 }


### PR DESCRIPTION
WIP Closes #1289 and #1283 for the members pallet

- [ ] optimize storage layout for iterating over timed out members
- [ ] re-run benchmarking => generate weights
- [ ] increase MaxHeartbeatTimeoutsPerBlock