### PR TITLE
node: fix overhead and extrinsic benchmark

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -3,7 +3,7 @@
 mod chain_spec;
 #[macro_use]
 mod service;
-//mod benchmarking;
+mod benchmarking;
 mod cli;
 mod command;
 mod rpc;

--- a/runtimes/common/src/lib.rs
+++ b/runtimes/common/src/lib.rs
@@ -130,7 +130,7 @@ pub type SignedExtra<Runtime> = (
 use time_primitives::{AccountId, Signature};
 
 /// The address format for describing accounts.
-type Address = sp_runtime::MultiAddress<AccountId, ()>;
+pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
 
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic<Runtime, Call> =
@@ -138,6 +138,9 @@ pub type UncheckedExtrinsic<Runtime, Call> =
 /// The payload being signed in transactions.
 pub type SignedPayload<Runtime, Call> =
 	sp_runtime::generic::SignedPayload<Call, SignedExtra<Runtime>>;
+
+/// Type shorthand for the balance type used to charge transaction fees
+pub type PaymentBalanceOf<T> = <<T as pallet_transaction_payment::Config>::OnChargeTransaction as pallet_transaction_payment::OnChargeTransaction<T>>::Balance;
 
 /// Shared default babe genesis config
 pub const BABE_GENESIS_EPOCH_CONFIG: sp_consensus_babe::BabeEpochConfiguration =


### PR DESCRIPTION
## Description

This bring back the previously disabled `overhead` and `extrinsic` benchmark command.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Tests

While this passes compilations, it will require some further work to fix the actual benchmark environment. Currently the benchmarks still crash once run:

```
$ timechain-node benchmark overhead
2024-12-09 16:53:18 🔨 Initializing Genesis block/state (state: 0x81b4…0774, header-hash: 0x0614…b943)    
2024-12-09 16:53:18 👴 Loading GRANDPA authority set from genesis on what appears to be first startup.    
2024-12-09 16:53:18 👶 Creating empty BABE epoch changes on what appears to be first startup.    
2024-12-09 16:53:18 Running 10 warmups...    
2024-12-09 16:53:18 Executing block 100 times    
2024-12-09 16:53:18 Per-block execution overhead [ns]:
Total: 135608518
Min: 1345486, Max: 1384896
Average: 1356085, Median: 1355216, Stddev: 6351.53
Percentiles 99th, 95th, 75th: 1372156, 1369485, 1358645    
2024-12-09 16:53:18 Writing weights to "/home/florian/Analog/timechain/block_weights.rs"    
2024-12-09 16:53:18 Running 10 warmups...    
2024-12-09 16:53:18 Executing block 100 times    
2024-12-09 16:53:19 Building block, this takes some time...    
2024-12-09 16:53:19 panicked at /build/runtime/src/lib.rs:1054:1:
Bad input data provided to apply_extrinsic: Codec error    
Error: Client(RuntimeApiError(Application(Execution(AbortedDueToTrap(MessageWithBacktrace { message: "wasm trap: wasm `unreachable` instruction executed", backtrace: Some(Backtrace { backtrace_string: "error while executing at wasm backtrace:\n    0: 0x5b178 - <unknown>!rust_begin_unwind\n    1: 0xc790 - <unknown>!core::panicking::panic_fmt::hc82e354c210abc88\n    2: 0xf0f6f - <unknown>!BlockBuilder_apply_extrinsic" }) })))))
```

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Inline comments have been added for each method
- [ ] I have made corresponding changes to the documentation
- [ ] Code changes introduces no new problems or warnings
- [ ] Test cases have been added 
- [ ] Dependent changes have been merged and published in downstream modules