### PR TITLE
WIP Fix Bench Overhead

### DIFF
--- a/node/block_weights.rs
+++ b/node/block_weights.rs
@@ -1,0 +1,59 @@
+
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 42.0.0
+//! DATE: 2024-12-17 (Y/M/D)
+//! HOSTNAME: `Amars-MacBook-Pro.local`, CPU: `<UNKNOWN>`
+//!
+//! SHORT-NAME: `block`, LONG-NAME: `BlockExecution`, RUNTIME: `Analog Testnet`
+//! WARMUPS: `10`, REPEAT: `100`
+//! WEIGHT-PATH: ``
+//! WEIGHT-METRIC: `Average`, WEIGHT-MUL: `1.0`, WEIGHT-ADD: `0`
+
+// Executed Command:
+//   ../target/release/timechain-node
+//   benchmark
+//   overhead
+
+use sp_core::parameter_types;
+use sp_weights::{constants::WEIGHT_REF_TIME_PER_NANOS, Weight};
+
+parameter_types! {
+	/// Time to execute an empty block.
+	/// Calculated by multiplying the *Average* with `1.0` and adding `0`.
+	///
+	/// Stats nanoseconds:
+	///   Min, Max: 364_274, 842_689
+	///   Average:  419_901
+	///   Median:   394_252
+	///   Std-Dev:  71644.43
+	///
+	/// Percentiles nanoseconds:
+	///   99th: 810_170
+	///   95th: 471_934
+	///   75th: 457_767
+	pub const BlockExecutionWeight: Weight =
+		Weight::from_parts(WEIGHT_REF_TIME_PER_NANOS.saturating_mul(419_901), 0);
+}
+
+#[cfg(test)]
+mod test_weights {
+	use sp_weights::constants;
+
+	/// Checks that the weight exists and is sane.
+	// NOTE: If this test fails but you are sure that the generated values are fine,
+	// you can delete it.
+	#[test]
+	fn sane() {
+		let w = super::BlockExecutionWeight::get();
+
+		// At least 100 µs.
+		assert!(
+			w.ref_time() >= 100u64 * constants::WEIGHT_REF_TIME_PER_MICROS,
+			"Weight should be at least 100 µs."
+		);
+		// At most 50 ms.
+		assert!(
+			w.ref_time() <= 50u64 * constants::WEIGHT_REF_TIME_PER_MILLIS,
+			"Weight should be at most 50 ms."
+		);
+	}
+}

--- a/runtimes/mainnet/src/lib.rs
+++ b/runtimes/mainnet/src/lib.rs
@@ -1641,7 +1641,11 @@ impl_runtime_apis! {
 
 	impl sp_block_builder::BlockBuilder<Block> for Runtime {
 		fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
-			Executive::apply_extrinsic(extrinsic)
+			let result = Executive::apply_extrinsic(extrinsic.clone());
+			if let Err(e) = result {
+				panic!("Failed extrinsic: {:?}, error: {:?}", extrinsic, e);
+			}
+			result
 		}
 
 		fn finalize_block() -> <Block as BlockT>::Header {

--- a/runtimes/testnet/src/lib.rs
+++ b/runtimes/testnet/src/lib.rs
@@ -1241,7 +1241,11 @@ impl_runtime_apis! {
 
 	impl sp_block_builder::BlockBuilder<Block> for Runtime {
 		fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
-			Executive::apply_extrinsic(extrinsic)
+			let result = Executive::apply_extrinsic(extrinsic.clone());
+			if let Err(e) = result {
+				panic!("Failed extrinsic: {:?}, error: {:?}", extrinsic, e);
+			}
+			result
 		}
 
 		fn finalize_block() -> <Block as BlockT>::Header {


### PR DESCRIPTION
WIP to fix #1336 

Currently running `RUST_LOG=runtime=debug ../target/release/timechain-node benchmark overhead` and still not clear which extrinsic has incorrectly formed inputs. Once we know which input has incorrectly formed inputs, it will be much easier to fix.