### PR TITLE
Include root in all admin origins

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1431,11 +1431,7 @@ type SystemAdmin = EitherOfDiverse<EnsureRoot<AccountId>, TechnicalUnanimity>;
 
 #[cfg(not(feature = "testnet"))]
 /// Default admin origin for staking related governance
-<<<<<<< HEAD
-type StakingAdmin = EitherOfDiverse<EnsureRoot<AccountId>, TechnicalQualifiedMajority>;
-=======
-type StakingAdmin = EitherOfDiverse<Root, TechnicalSuperMajority>;
->>>>>>> 55f7a5feb02ded7f898cff1464e940e99c78089e
+type StakingAdmin = EitherOfDiverse<EnsureRoot<AccountId>, TechnicalSuperMajority>;
 
 #[cfg(not(feature = "testnet"))]
 /// Default admin origin for all chronicle related pallets


### PR DESCRIPTION
Closes #1344 by augmenting all admin origin type definitions with Root. One consequence is RawOrigin::Root may be used in pallet benchmarking for our custom pallet origins which should fix the failing benchmarks.

- [x] run CI benchmarking to verify that failing benchmarks are passing (except timegraph)

## Follow Up

* https://github.com/Analog-Labs/timechain/issues/1350