### PR TITLE
[chain spec] endow runtime-given Treasury account

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -15,8 +15,8 @@ use sp_core::crypto::UncheckedInto;
 use sp_keyring::{AccountKeyring, Ed25519Keyring};
 use sp_runtime::Perbill;
 
-use timechain_runtime::{WASM_BINARY, StakerStatus, Treasury};
 use time_primitives::{AccountId, Balance, Block, ANLOG, SS58_PREFIX, TOKEN_DECIMALS};
+use timechain_runtime::{StakerStatus, Treasury, WASM_BINARY};
 
 /// Total supply of token is 90_570_710.
 /// Initially we are distributing the total supply to the multiple accounts which is representing
@@ -117,7 +117,7 @@ impl Default for GenesisKeysConfig {
 			// TODO: Would be better to assign individual controllers
 			controller: None,
 			endowments: vec![(
-			    // 6d6f646c70792f74727372790000000000000000000000000000000000000000
+				// 6d6f646c70792f74727372790000000000000000000000000000000000000000
 				Treasury::account_id(),
 				TREASURY_SUPPLY,
 			)],


### PR DESCRIPTION
(this should fix https://github.com/Analog-Labs/timechain/issues/1361)

Treasury account Id is calculated from the Treasury pallet Id:

https://github.com/Analog-Labs/polkadot-sdk/blob/066faa1fa2f673f5ce0e9df271bf0d04c56ef841/substrate/frame/treasury/src/lib.rs#L793-L795

Once we set the Treasury pallet Id in the runtime, this is the only place where its account id can be changed.
Thus this PR proposes error-prone Treasury account endowment for the default chain spec, instead of using some magic hex constant + unreliable runtime tests to check its validity. 