### PR TITLE
Fix receiving redundant evm msgs

### DIFF
--- a/gmp/evm/src/lib.rs
+++ b/gmp/evm/src/lib.rs
@@ -500,7 +500,7 @@ impl IConnector for Connector {
 				topics: vec![],
 				block: FilterBlockOption::Range {
 					from_block: Some(blocks.start.into()),
-					// Evm fetches blocks from both ranges that is provided. This makes end block exclusive.
+					// Evm fetches logs from both blocks that is provided in range. This makes end block exclusive.
 					to_block: Some((blocks.end - 1).into()),
 				},
 			})


### PR DESCRIPTION
## Description

Due to Rust (Range)[https://doc.rust-lang.org/std/ops/struct.Range.html] we have end exclusive of serach but `eth_getLogs` include the end so we have been repetitive messages from gateway and executing them throws `msg already executed` error from gateway. This PR removes the inclusive end to exclusive. 

Fixes # (issue)
https://github.com/Analog-Labs/timechain/issues/1411

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] `benchmark`


## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Inline comments have been added for each method
- [x] I have made corresponding changes to the documentation
- [x] Code changes introduces no new problems or warnings
- [x] Test cases have been added 
- [x] Dependent changes have been merged and published in downstream modules