### PR TITLE
set admin origin for timgraph pallet

### DIFF
--- a/pallets/timegraph/src/lib.rs
+++ b/pallets/timegraph/src/lib.rs
@@ -85,6 +85,7 @@ pub mod pallet {
 		type InitialTimegraphAccount: Get<Self::AccountId>;
 		#[pallet::constant]
 		type InitialRewardPoolAccount: Get<Self::AccountId>;
+		type AdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 	}
 
 	///Stores the next deposit sequence number for each account.
@@ -357,7 +358,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			account: T::AccountId,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			ensure!(
 				account.clone() != TimegraphAccount::<T>::get(),
 				Error::<T>::SameTimegraphAccount
@@ -386,7 +387,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			account: T::AccountId,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 
 			ensure!(
 				account.clone() != RewardPoolAccount::<T>::get(),
@@ -413,7 +414,7 @@ pub mod pallet {
 		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::withdraw())]
 		pub fn set_threshold(origin: OriginFor<T>, amount: BalanceOf<T>) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 
 			ensure!(amount != Threshold::<T>::get(), Error::<T>::SameThreshold);
 

--- a/pallets/timegraph/src/mock.rs
+++ b/pallets/timegraph/src/mock.rs
@@ -50,6 +50,7 @@ impl pallet_timegraph::Config for Test {
 	type InitialThreshold = ConstU128<1_000>;
 	type InitialRewardPoolAccount = ConstU64<1>;
 	type InitialTimegraphAccount = ConstU64<2>;
+	type AdminOrigin = frame_system::EnsureRoot<AccountId>;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/runtime/src/configs/custom.rs
+++ b/runtime/src/configs/custom.rs
@@ -88,6 +88,7 @@ impl pallet_timegraph::Config for Runtime {
 	type InitialRewardPoolAccount = InitialRewardPoolAccount;
 	type InitialTimegraphAccount = InitialTimegraphAccount;
 	type InitialThreshold = InitialThreshold;
+	type AdminOrigin = EnsureRootOrTechnicalMember;
 }
 
 impl pallet_networks::Config for Runtime {


### PR DESCRIPTION
## Description
Before we use the sudo to set the parameters of timegraph pallet like timegraph account. Since the sudo is removed, we need different priviledged origin. set it as EnsureRootOrTechnicalMember, then technical member can update.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Tests

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:

## Code review prechecks:

- [ ] Code follows the style guidelines of this project
- [ ] Code has been self-reviewed
- [ ] Inline comments have been added for each method
- [ ] I have made corresponding changes to the documentation
- [ ] Code changes introduces no new problems or warnings
- [ ] Test cases have been added 
- [ ] Dependent changes have been merged and published in downstream modules