### PR TITLE
Retry failed tasks via admin

### DIFF
--- a/chronicle/src/tasks/mod.rs
+++ b/chronicle/src/tasks/mod.rs
@@ -7,8 +7,8 @@ use scale_codec::Encode;
 use std::sync::Arc;
 use std::{collections::BTreeMap, pin::Pin};
 use time_primitives::{
-	Address, BlockNumber, ErrorMsg, GatewayOp, GmpEvents, GmpParams, IConnector, NetworkId,
-	ShardId, Task, TaskId, TaskResult, TssSignature, TssSigningRequest,
+	Address, BlockNumber, ErrorMsg, GmpEvents, GmpParams, IConnector, NetworkId, ShardId, Task,
+	TaskId, TaskResult, TssSignature, TssSigningRequest,
 };
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;

--- a/chronicle/src/tasks/mod.rs
+++ b/chronicle/src/tasks/mod.rs
@@ -7,8 +7,8 @@ use scale_codec::Encode;
 use std::sync::Arc;
 use std::{collections::BTreeMap, pin::Pin};
 use time_primitives::{
-	Address, BlockNumber, ErrorMsg, GmpEvents, GmpParams, IConnector, NetworkId, ShardId, Task,
-	TaskId, TaskResult, TssSignature, TssSigningRequest,
+	Address, BlockNumber, ErrorMsg, GatewayOp, GmpEvents, GmpParams, IConnector, NetworkId,
+	ShardId, Task, TaskId, TaskResult, TssSignature, TssSigningRequest,
 };
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;

--- a/pallets/tasks/src/benchmarking.rs
+++ b/pallets/tasks/src/benchmarking.rs
@@ -1,6 +1,6 @@
 use crate::{
-	BatchIdCounter, Call, Config, Pallet, ReadEventsTask, ShardRegistered, TaskIdCounter,
-	TaskOutput, TaskShard,
+	BatchIdCounter, BatchTaskId, Call, Config, FailedBatchIds, Pallet, ReadEventsTask,
+	ShardRegistered, TaskIdCounter, TaskNetwork, TaskOutput, TaskShard,
 };
 use frame_benchmarking::benchmarks;
 use frame_support::pallet_prelude::Get;
@@ -143,5 +143,29 @@ benchmarks! {
 		TaskOutput::<T>::insert(task_id, Ok::<(), ErrorMsg>(()));
 	}: _(RawOrigin::Root, task_id) verify { }
 
+
+	restart_batch {
+		create_shard::<T>(ETHEREUM);
+		let network = ETHEREUM;
+		let batch_id = BatchIdCounter::<T>::get();
+		let initial_task_id = Pallet::<T>::create_task(
+			network,
+			Task::SubmitGatewayMessage { batch_id }
+		);
+		FailedBatchIds::<T>::mutate(|ids| ids.push(batch_id));
+		BatchTaskId::<T>::insert(batch_id, initial_task_id);
+		TaskNetwork::<T>::insert(initial_task_id, network);
+	}: _(RawOrigin::Root, batch_id) verify {
+		let new_task_id = initial_task_id + 1;
+		assert_eq!(
+			BatchTaskId::<T>::get(batch_id),
+			Some(new_task_id),
+			"New task ID not properly set"
+		);
+		assert!(
+			!FailedBatchIds::<T>::get().contains(&batch_id),
+			"Batch not removed from failed list"
+		);
+	}
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/pallets/tasks/src/benchmarking.rs
+++ b/pallets/tasks/src/benchmarking.rs
@@ -145,7 +145,7 @@ benchmarks! {
 
 
 	restart_batch {
-		let l in 1..100;
+		let l in 1..1000;
 		create_shard::<T>(ETHEREUM);
 		let network = ETHEREUM;
 		let failed_batches: Vec<BatchId> = (0..l).map(|l| l as BatchId).collect();

--- a/pallets/tasks/src/benchmarking.rs
+++ b/pallets/tasks/src/benchmarking.rs
@@ -172,12 +172,6 @@ benchmarks! {
 			!FailedBatchIds::<T>::get().contains(&target_batch_id),
 			"Batch not removed from failed list"
 		);
-		assert_eq!(
-			FailedBatchIds::<T>::get().len(),
-			(l - 1) as usize,
-			"List length mismatch"
-		);
-
 	   }
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/pallets/tasks/src/benchmarking.rs
+++ b/pallets/tasks/src/benchmarking.rs
@@ -13,7 +13,7 @@ use polkadot_sdk::{frame_benchmarking, frame_support, frame_system, sp_core, sp_
 use sp_runtime::{BoundedVec, Vec};
 use sp_std::vec;
 use time_primitives::{
-	AccountId, BatchId, Commitment, ElectionsInterface, ErrorMsg, GmpEvents, NetworkId, PublicKey,
+	AccountId, Commitment, ElectionsInterface, ErrorMsg, GmpEvents, NetworkId, PublicKey,
 	ShardStatus, ShardsInterface, Task, TaskId, TaskResult, TasksInterface, TssPublicKey,
 	TssSignature,
 };
@@ -164,7 +164,7 @@ benchmarks! {
 			"New task not created"
 		);
 		assert!(
-			!FailedBatchIds::<T>::contains_key(&batch_id),
+			!FailedBatchIds::<T>::contains_key(batch_id),
 			"Batch not removed from failed list"
 		);
 	}

--- a/pallets/tasks/src/lib.rs
+++ b/pallets/tasks/src/lib.rs
@@ -83,7 +83,7 @@ pub mod pallet {
 		fn sync_network() -> Weight;
 		fn stop_network() -> Weight;
 		fn remove_task() -> Weight;
-		fn restart_batch() -> Weight;
+		fn restart_batch(n: u32) -> Weight;
 	}
 
 	impl WeightInfo for () {
@@ -108,7 +108,7 @@ pub mod pallet {
 		fn remove_task() -> Weight {
 			Weight::default()
 		}
-		fn restart_batch() -> Weight {
+		fn restart_batch(_n: u32) -> Weight {
 			Weight::default()
 		}
 	}
@@ -451,7 +451,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(14)]
-		#[pallet::weight(<T as Config>::WeightInfo::restart_batch())]
+		#[pallet::weight(<T as Config>::WeightInfo::restart_batch(FailedBatchIds::<T>::decode_len().unwrap_or(0) as u32))]
 		pub fn restart_batch(origin: OriginFor<T>, batch_id: BatchId) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
 			let old_task_id = BatchTaskId::<T>::get(batch_id).ok_or(Error::<T>::InvalidBatchId)?;

--- a/pallets/tasks/src/tests.rs
+++ b/pallets/tasks/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{mock::*, BatchTaskId, Event};
+use crate::{mock::*, BatchTaskId, Event, FailedBatchIds};
 use crate::{BatchIdCounter, BatchTxHash, ShardRegistered};
 
 use frame_support::assert_ok;
@@ -418,12 +418,12 @@ fn test_restart_failed_batch() {
 		roll(1);
 		let submitter = Tasks::get_task_submitter(initial_task_id).unwrap();
 		submit_submission_error(submitter, initial_task_id, "batch failed");
-		assert!(Tasks::get_failed_tasks().contains(&batch_id));
+		assert!(FailedBatchIds::<Test>::contains_key(&batch_id));
 		assert_ok!(Tasks::restart_batch(RawOrigin::Root.into(), batch_id));
 		let new_task_id = 3;
 		assert_eq!(Tasks::get_task(new_task_id), Some(Task::SubmitGatewayMessage { batch_id }));
 		assert_eq!(BatchTaskId::<Test>::get(batch_id), Some(new_task_id));
-		assert!(!Tasks::get_failed_tasks().contains(&batch_id));
+		assert!(!FailedBatchIds::<Test>::contains_key(&batch_id));
 		assert!(Tasks::get_task_result(initial_task_id).is_some());
 		let event = System::events().into_iter().find_map(|r| {
 			if let RuntimeEvent::Tasks(Event::BatchRestarted(old, new)) = r.event {

--- a/pallets/tasks/src/tests.rs
+++ b/pallets/tasks/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::mock::*;
+use crate::{mock::*, BatchTaskId, Event};
 use crate::{BatchIdCounter, BatchTxHash, ShardRegistered};
 
 use frame_support::assert_ok;
@@ -403,6 +403,37 @@ fn test_task_stuck_in_unassigned_queue() {
 		roll(1);
 		assert!(Tasks::get_task_shard(9).is_some());
 	})
+}
+
+#[test]
+fn test_restart_failed_batch() {
+	new_test_ext().execute_with(|| {
+		register_gateway(ETHEREUM, 42);
+		let shard = create_shard(ETHEREUM, 3, 1);
+		roll(1);
+		let batch_id = 0;
+		let initial_task_id = 2;
+		Tasks::assign_task(shard, 2);
+		assert_eq!(Tasks::get_task(initial_task_id), Some(Task::SubmitGatewayMessage { batch_id }));
+		roll(1);
+		let submitter = Tasks::get_task_submitter(initial_task_id).unwrap();
+		submit_submission_error(submitter, initial_task_id, "batch failed");
+		assert!(Tasks::get_failed_tasks().contains(&batch_id));
+		assert_ok!(Tasks::restart_batch(RawOrigin::Root.into(), batch_id));
+		let new_task_id = 3;
+		assert_eq!(Tasks::get_task(new_task_id), Some(Task::SubmitGatewayMessage { batch_id }));
+		assert_eq!(BatchTaskId::<Test>::get(batch_id), Some(new_task_id));
+		assert!(!Tasks::get_failed_tasks().contains(&batch_id));
+		assert!(Tasks::get_task_result(initial_task_id).is_some());
+		let event = System::events().into_iter().find_map(|r| {
+			if let RuntimeEvent::Tasks(Event::BatchRestarted(old, new)) = r.event {
+				Some((old, new))
+			} else {
+				None
+			}
+		});
+		assert_eq!(event, Some((initial_task_id, new_task_id)));
+	});
 }
 
 mod bench_helper {

--- a/pallets/tasks/src/tests.rs
+++ b/pallets/tasks/src/tests.rs
@@ -418,12 +418,12 @@ fn test_restart_failed_batch() {
 		roll(1);
 		let submitter = Tasks::get_task_submitter(initial_task_id).unwrap();
 		submit_submission_error(submitter, initial_task_id, "batch failed");
-		assert!(FailedBatchIds::<Test>::contains_key(&batch_id));
+		assert!(FailedBatchIds::<Test>::contains_key(batch_id));
 		assert_ok!(Tasks::restart_batch(RawOrigin::Root.into(), batch_id));
 		let new_task_id = 3;
 		assert_eq!(Tasks::get_task(new_task_id), Some(Task::SubmitGatewayMessage { batch_id }));
 		assert_eq!(BatchTaskId::<Test>::get(batch_id), Some(new_task_id));
-		assert!(!FailedBatchIds::<Test>::contains_key(&batch_id));
+		assert!(!FailedBatchIds::<Test>::contains_key(batch_id));
 		assert!(Tasks::get_task_result(initial_task_id).is_some());
 		let event = System::events().into_iter().find_map(|r| {
 			if let RuntimeEvent::Tasks(Event::BatchRestarted(old, new)) = r.event {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -144,6 +144,7 @@ sp_api::decl_runtime_apis! {
 		fn get_task_submitter(task_id: TaskId) -> Option<PublicKey>;
 		fn get_task_result(task_id: TaskId) -> Option<Result<(), ErrorMsg>>;
 		fn get_batch_message(batch_id: BatchId) -> Option<GatewayMessage>;
+		fn get_failed_tasks() -> Vec<TaskId>;
 	}
 
 	pub trait SubmitTransactionApi{

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -364,6 +364,10 @@ impl_runtime_apis! {
 		fn get_batch_message(batch_id: BatchId) -> Option<GatewayMessage> {
 			Tasks::get_batch_message(batch_id)
 		}
+
+		fn get_failed_tasks() -> Vec<TaskId> {
+			Tasks::get_failed_tasks()
+		}
 	}
 
 	#[cfg(feature = "testnet")]

--- a/runtime/src/weights/develop/pallet_tasks.rs
+++ b/runtime/src/weights/develop/pallet_tasks.rs
@@ -208,4 +208,22 @@ impl<T: frame_system::Config> pallet_tasks::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
+	/// Storage: `Tasks::TaskOutput` (r:1 w:1)
+	/// Proof: `Tasks::TaskOutput` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Tasks::Tasks` (r:1 w:1)
+	/// Proof: `Tasks::Tasks` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Tasks::TaskSubmitter` (r:0 w:1)
+	/// Proof: `Tasks::TaskSubmitter` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Tasks::TaskNetwork` (r:0 w:1)
+	/// Proof: `Tasks::TaskNetwork` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	fn restart_batch() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `286`
+		//  Estimated: `3751`
+		// Minimum execution time: 21_431_000 picoseconds.
+		Weight::from_parts(25_146_000, 0)
+			.saturating_add(Weight::from_parts(0, 3751))
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(4))
+	}
 }

--- a/runtime/src/weights/develop/pallet_tasks.rs
+++ b/runtime/src/weights/develop/pallet_tasks.rs
@@ -216,7 +216,7 @@ impl<T: frame_system::Config> pallet_tasks::WeightInfo for WeightInfo<T> {
 	/// Proof: `Tasks::TaskSubmitter` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Tasks::TaskNetwork` (r:0 w:1)
 	/// Proof: `Tasks::TaskNetwork` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn restart_batch(_n: u32) -> Weight {
+	fn restart_batch() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `286`
 		//  Estimated: `3751`

--- a/runtime/src/weights/develop/pallet_tasks.rs
+++ b/runtime/src/weights/develop/pallet_tasks.rs
@@ -216,7 +216,7 @@ impl<T: frame_system::Config> pallet_tasks::WeightInfo for WeightInfo<T> {
 	/// Proof: `Tasks::TaskSubmitter` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Tasks::TaskNetwork` (r:0 w:1)
 	/// Proof: `Tasks::TaskNetwork` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn restart_batch() -> Weight {
+	fn restart_batch(_n: u32) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `286`
 		//  Estimated: `3751`

--- a/runtime/src/weights/mainnet/pallet_tasks.rs
+++ b/runtime/src/weights/mainnet/pallet_tasks.rs
@@ -210,4 +210,22 @@ impl<T: frame_system::Config> pallet_tasks::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
+	/// Storage: `Tasks::TaskOutput` (r:1 w:1)
+	/// Proof: `Tasks::TaskOutput` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Tasks::Tasks` (r:1 w:1)
+	/// Proof: `Tasks::Tasks` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Tasks::TaskSubmitter` (r:0 w:1)
+	/// Proof: `Tasks::TaskSubmitter` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Tasks::TaskNetwork` (r:0 w:1)
+	/// Proof: `Tasks::TaskNetwork` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	fn restart_batch() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `286`
+		//  Estimated: `3751`
+		// Minimum execution time: 8_666_000 picoseconds.
+		Weight::from_parts(8_986_000, 0)
+			.saturating_add(Weight::from_parts(0, 3751))
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(4))
+	}
 }

--- a/runtime/src/weights/mainnet/pallet_tasks.rs
+++ b/runtime/src/weights/mainnet/pallet_tasks.rs
@@ -218,7 +218,7 @@ impl<T: frame_system::Config> pallet_tasks::WeightInfo for WeightInfo<T> {
 	/// Proof: `Tasks::TaskSubmitter` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Tasks::TaskNetwork` (r:0 w:1)
 	/// Proof: `Tasks::TaskNetwork` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn restart_batch() -> Weight {
+	fn restart_batch(_n: u32) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `286`
 		//  Estimated: `3751`

--- a/runtime/src/weights/mainnet/pallet_tasks.rs
+++ b/runtime/src/weights/mainnet/pallet_tasks.rs
@@ -218,7 +218,7 @@ impl<T: frame_system::Config> pallet_tasks::WeightInfo for WeightInfo<T> {
 	/// Proof: `Tasks::TaskSubmitter` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Tasks::TaskNetwork` (r:0 w:1)
 	/// Proof: `Tasks::TaskNetwork` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn restart_batch(_n: u32) -> Weight {
+	fn restart_batch() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `286`
 		//  Estimated: `3751`

--- a/runtime/src/weights/testnet/pallet_tasks.rs
+++ b/runtime/src/weights/testnet/pallet_tasks.rs
@@ -210,4 +210,22 @@ impl<T: frame_system::Config> pallet_tasks::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
+	/// Storage: `Tasks::TaskOutput` (r:1 w:1)
+	/// Proof: `Tasks::TaskOutput` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Tasks::Tasks` (r:1 w:1)
+	/// Proof: `Tasks::Tasks` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Tasks::TaskSubmitter` (r:0 w:1)
+	/// Proof: `Tasks::TaskSubmitter` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Tasks::TaskNetwork` (r:0 w:1)
+	/// Proof: `Tasks::TaskNetwork` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	fn restart_batch() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `286`
+		//  Estimated: `3751`
+		// Minimum execution time: 12_533_000 picoseconds.
+		Weight::from_parts(12_894_000, 0)
+			.saturating_add(Weight::from_parts(0, 3751))
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(4))
+	}
 }

--- a/runtime/src/weights/testnet/pallet_tasks.rs
+++ b/runtime/src/weights/testnet/pallet_tasks.rs
@@ -218,7 +218,7 @@ impl<T: frame_system::Config> pallet_tasks::WeightInfo for WeightInfo<T> {
 	/// Proof: `Tasks::TaskSubmitter` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Tasks::TaskNetwork` (r:0 w:1)
 	/// Proof: `Tasks::TaskNetwork` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn restart_batch() -> Weight {
+	fn restart_batch(_n: u32) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `286`
 		//  Estimated: `3751`

--- a/runtime/src/weights/testnet/pallet_tasks.rs
+++ b/runtime/src/weights/testnet/pallet_tasks.rs
@@ -218,7 +218,7 @@ impl<T: frame_system::Config> pallet_tasks::WeightInfo for WeightInfo<T> {
 	/// Proof: `Tasks::TaskSubmitter` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Tasks::TaskNetwork` (r:0 w:1)
 	/// Proof: `Tasks::TaskNetwork` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn restart_batch(_n: u32) -> Weight {
+	fn restart_batch() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `286`
 		//  Estimated: `3751`

--- a/tc-cli/src/lib.rs
+++ b/tc-cli/src/lib.rs
@@ -561,6 +561,15 @@ impl Tc {
 		Ok(tasks)
 	}
 
+	pub async fn assigned_tasks(&self, shard: ShardId) -> Result<Vec<Task>> {
+		let task_ids = self.runtime.assigned_tasks(shard).await?;
+		let mut tasks = Vec::with_capacity(task_ids.len());
+		for id in task_ids {
+			tasks.push(self.task(id).await?);
+		}
+		Ok(tasks)
+	}
+
 	pub async fn members(&self, shard: ShardId) -> Result<Vec<Member>> {
 		let shard_members = self.runtime.shard_members(shard).await?;
 		let mut members = Vec::with_capacity(shard_members.len());

--- a/tc-cli/src/lib.rs
+++ b/tc-cli/src/lib.rs
@@ -561,13 +561,13 @@ impl Tc {
 		Ok(tasks)
 	}
 
-	pub async fn assigned_tasks(&self, shard: ShardId) -> Result<Vec<Task>> {
-		let task_ids = self.runtime.assigned_tasks(shard).await?;
-		let mut tasks = Vec::with_capacity(task_ids.len());
-		for id in task_ids {
-			tasks.push(self.task(id).await?);
+	pub async fn get_failed_batches(&self) -> Result<Vec<Batch>> {
+		let batch_ids = self.runtime.get_failed_tasks().await?;
+		let mut batches = Vec::with_capacity(batch_ids.len());
+		for id in batch_ids {
+			batches.push(self.batch(id).await?);
 		}
-		Ok(tasks)
+		Ok(batches)
 	}
 
 	pub async fn members(&self, shard: ShardId) -> Result<Vec<Member>> {
@@ -866,6 +866,11 @@ impl Tc {
 		}
 		self.println(None, format!("force_shard_offline {}", shard)).await?;
 		self.runtime.force_shard_offline(shard).await?;
+		Ok(())
+	}
+
+	pub async fn restart_failed_batch(&self, batch_id: BatchId) -> Result<()> {
+		self.runtime.restart_failed_batch(batch_id).await?;
 		Ok(())
 	}
 }

--- a/tc-cli/src/main.rs
+++ b/tc-cli/src/main.rs
@@ -525,6 +525,7 @@ async fn real_main() -> Result<()> {
 				hex::decode(hash)?.try_into().map_err(|_| anyhow::anyhow!("invalid hash"))?;
 			let output = tc.debug_transaction(network, hash).await?;
 			tc.println(None, output).await?;
+		},
 		Command::RetryFailedBatch { batch_id } => {
 			tc.restart_failed_batch(batch_id).await?;
 		},

--- a/tc-subxt/src/api/tasks.rs
+++ b/tc-subxt/src/api/tasks.rs
@@ -30,6 +30,11 @@ impl SubxtClient {
 		Ok(self.client.runtime_api().at_latest().await?.call(runtime_call).await?)
 	}
 
+	pub async fn list_failed_tasks(&self) -> Result<Vec<TaskId>> {
+		let runtime_call = metadata::apis().tasks_api().get_failed_tasks();
+		Ok(self.client.runtime_api().at_latest().await?.call(runtime_call).await?)
+	}
+
 	pub async fn unassigned_tasks(&self, network: NetworkId) -> Result<Vec<TaskId>> {
 		let storage_query = metadata::storage().tasks().ua_tasks_iter1(network);
 		let mut items = self.client.storage().at_latest().await?.iter(storage_query).await?;

--- a/tc-subxt/src/api/tasks.rs
+++ b/tc-subxt/src/api/tasks.rs
@@ -89,7 +89,7 @@ impl SubxtClient {
 		let (tx, rx) = oneshot::channel();
 		self.tx.unbounded_send((Tx::RestartBatch { batch_id }, tx))?;
 		let tx = rx.await?;
-		self.wait_for_success(tx).await?;
+		self.is_success(&tx).await?;
 		Ok(())
 	}
 

--- a/tc-subxt/src/worker.rs
+++ b/tc-subxt/src/worker.rs
@@ -269,7 +269,7 @@ where
 					metadata::runtime_types::pallet_tasks::pallet::Call::restart_batch { batch_id },
 				);
 				let payload = metadata::sudo(runtime_call);
-				self.create_signed_payload(&payload, params)
+				self.client.sign_payload(&payload, params)
 			},
 		}
 	}

--- a/tc-subxt/src/worker.rs
+++ b/tc-subxt/src/worker.rs
@@ -14,6 +14,7 @@ use std::pin::Pin;
 use subxt::config::DefaultExtrinsicParamsBuilder;
 use subxt::utils::H256;
 use subxt_signer::sr25519::Keypair;
+use time_primitives::BatchId;
 use time_primitives::{
 	traits::IdentifyAccount, AccountId, Commitment, GmpEvents, Network, NetworkConfig, NetworkId,
 	PeerId, ProofOfKnowledge, PublicKey, ShardId, TaskId, TaskResult,
@@ -77,6 +78,9 @@ pub enum Tx {
 	},
 	RemoveTask {
 		task_id: TaskId,
+	},
+	RestartBatch {
+		batch_id: BatchId,
 	},
 }
 
@@ -259,6 +263,13 @@ where
 				);
 				let payload = metadata::sudo(runtime_call);
 				self.client.sign_payload(&payload, params)
+			},
+			Tx::RestartBatch { batch_id } => {
+				let runtime_call = RuntimeCall::Tasks(
+					metadata::runtime_types::pallet_tasks::pallet::Call::restart_batch { batch_id },
+				);
+				let payload = metadata::sudo(runtime_call);
+				self.create_signed_payload(&payload, params)
 			},
 		}
 	}


### PR DESCRIPTION
## Description

- Saves failed tasks in a new storage in task pallet.
- Provides runtime api to get all failed tasks.
- Provides a new extrinsic to retry a failed task via admin.
- Provided tc-cli utils to list failed task.
- Provides tc-cli command to retry failed task.
- Adds tests in pallet task.
- Adds benchmarks for extrinsic `restart_batch`


Fixes # (issue)
closes: https://github.com/Analog-Labs/timechain/issues/1394

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Inline comments have been added for each method
- [x] I have made corresponding changes to the documentation
- [x] Code changes introduces no new problems or warnings
- [x] Test cases have been added 
- [x] Dependent changes have been merged and published in downstream modules