### PR TITLE
[ci] Tune up cargo test workflow run conditions

### DIFF
--- a/.github/workflows/pr-test-cargo.yaml
+++ b/.github/workflows/pr-test-cargo.yaml
@@ -1,23 +1,7 @@
 name: Check testsuite
 on:
   pull_request:
-    paths:
-      - '.github/actions/cargo-command/**'
-      - '.github/workflows/pr-test-cargo.yaml'
-      - 'chronicle/**'
-      - 'config/subxt/**'
-      - 'docs/**'
-      - 'node/**'
-      - 'pallets/**'
-      - 'primitives/**'
-      - 'runtime/**'
-      - 'tc-cli/**'
-      - 'tc-subxt/**'
-      - 'tss/**'
-      - 'utils/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain.toml'
+    types: [labeled, unlabeled, opened, reopened, synchronize]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr-test-cargo.yaml
+++ b/.github/workflows/pr-test-cargo.yaml
@@ -1,7 +1,23 @@
 name: Check testsuite
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, synchronize]
+    paths:
+      - '.github/actions/cargo-command/**'
+      - '.github/workflows/pr-test-cargo.yaml'
+      - 'chronicle/**'
+      - 'config/subxt/**'
+      - 'docs/**'
+      - 'node/**'
+      - 'pallets/**'
+      - 'primitives/**'
+      - 'runtime/**'
+      - 'tc-cli/**'
+      - 'tc-subxt/**'
+      - 'tss/**'
+      - 'utils/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr-test-cargo.yaml
+++ b/.github/workflows/pr-test-cargo.yaml
@@ -22,6 +22,6 @@ jobs:
         uses: ./.github/actions/cargo-command
         with:
           command: test
-          args: --all-features
+          args: --all-features --lib --bins
           cache: false
           annotate: false

--- a/.github/workflows/pr-test-compose.yaml
+++ b/.github/workflows/pr-test-compose.yaml
@@ -7,7 +7,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  if: false
   test-basic:
     runs-on: [self-hosted, integration]
     timeout-minutes: 90


### PR DESCRIPTION

**upd**: for now we just don't run integration tests in `.github/workflows/pr-test-cargo.yaml`, and keep tc-cli smoke in `.github/workflows/pr-test-compose.yaml` to unblock all failing CIs

Tunning this up further is a subj to a follow-up PRs 
cc @penumbra23 @dvc94ch 


We [turned off](https://github.com/Analog-Labs/timechain/pull/1557#discussion_r1959898556) the e2e smoke test job, as the same test now runs along all other ones in [Check testsuite](https://github.com/Analog-Labs/timechain/blob/77d119d59885988dd4c8773fd9dc32a44389f24b/.github/workflows/pr-test-cargo.yaml#L1) job. 

This change make the latter job run on the same conditions as the removed one used to.

