### PR TITLE
ci: upload compose logs into S3 bucket

### DIFF
--- a/.github/workflows/pr-test-compose.yaml
+++ b/.github/workflows/pr-test-compose.yaml
@@ -69,7 +69,9 @@ jobs:
         if: ${{ always() }}
         run: |
           mkdir -p logs
+          echo "Uploading container logs"
           for container in $(docker compose ps --services); do
+            echo "Export logs for $container"
             docker compose logs "$container" > "logs/$container.log"
           done
           aws s3 cp logs "s3://${BUCKET_NAME}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" --recursive

--- a/.github/workflows/pr-test-compose.yaml
+++ b/.github/workflows/pr-test-compose.yaml
@@ -6,6 +6,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+env:
+  BUCKET_NAME: compose-test-logs
 jobs:
   test-basic:
     runs-on: [self-hosted, integration]
@@ -70,7 +72,7 @@ jobs:
           for container in $(docker compose ps --services); do
             docker compose logs "$container" > "logs/$container.log"
           done
-          aws s3 cp logs "s3://compose-test-logs/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" --recursive
+          aws s3 cp logs "s3://${BUCKET_NAME}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" --recursive
       - name: Cleanup
         if: ${{ always() }}
         run: |

--- a/.github/workflows/pr-test-compose.yaml
+++ b/.github/workflows/pr-test-compose.yaml
@@ -55,6 +55,22 @@ jobs:
       - name: Still works
         run: |
           ${{ steps.tc-cli.outputs.TC_CLI }} smoke-test 2 3
+      - name: Set up AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.LOG_UPLOADER_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.LOG_UPLOADER_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+        # Upload logs step collects all the logs from the containers
+        # and uploads it in a S3 bucket
+      - name: Upload logs
+        if: ${{ always() }}
+        run: |
+          mkdir -p logs
+          for container in $(docker compose ps --services); do
+            docker compose logs "$container" > "logs/$container.log"
+          done
+          aws s3 cp logs "s3://compose-test-logs/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" --recursive
       - name: Cleanup
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
## Description

To be able to inspect all container logs, this PR uploads all container logs from the CI integration test run and uploads it into the compose test log S3 bucket.
The upload is triggered always to catch all possible logs. The AWS key required should have only S3 permissions for the specific bucket.

The path to the logs is determined by the workflow run ID and the run attempt (to avoid overwrite when someone re-runs failed jobs)

Closes #1560 