### PR TITLE
ci: add reset workflow (only development env)

### DIFF
--- a/.github/actions/tc-cli/action.yaml
+++ b/.github/actions/tc-cli/action.yaml
@@ -1,0 +1,43 @@
+name: "Dispatch tc-cli workflow"
+description: "Trigger a tc-cli command"
+
+inputs:
+  version:
+    description: "Docker image version tag"
+    required: true
+    default: "dev"
+  token:
+    description: "Github API Token"
+    required: true
+  environment:
+    description: "Target env for the tc-cli dispatch"
+    required: true
+  args:
+    description: "Tc-cli arguments"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Trigger dispatch
+      shell: bash
+      run: |
+        set -e;
+        
+        CODE=$(curl -X POST --silent --output curl_out \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ inputs.token }}" \
+            https://api.github.com/repos/Analog-Labs/timechain/actions/workflows/dispatch-tc-cli.yaml/dispatches \
+            -d '{
+                    "ref": "development",
+                    "inputs": {
+                        "version": "'${{ inputs.version }}'",
+                        "environment": "'${{ inputs.environment }}'",
+                        "args": "'${{ inputs.args }}'"
+                    }
+                }' --write-out "%{http_code}" "$@");
+
+        if [[ ${CODE} -lt 200 || ${CODE} -gt 299 ]] ; then
+          cat curl_out;
+          exit 1;
+        fi

--- a/.github/workflows/dispatch-reset-cluster.yaml
+++ b/.github/workflows/dispatch-reset-cluster.yaml
@@ -1,0 +1,57 @@
+name: Reset Timechain
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment to reset"
+        required: true
+        type: string
+        options:
+          - development
+
+jobs:
+  reset-timechain:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: GKE Setup
+        uses: ./.github/actions/gke-common
+        with:
+          cluster: ${{ github.event.inputs.environment }}
+          key-file: ${{ secrets.TIMECHAIN_RESET_KEY }}
+          project-id: ${{ secrets.GCP_PROJECT_ID }}
+          region: us-east1
+
+      - name: Install helm
+        uses: azure/setup-helm@v4.3.0
+
+      - name: Purge cluster
+        run: |
+          NAMESPACE="timechain"
+          LATEST_REVISION=$(helm history ${{ secrets.RELESE_NAME }} -n $NAMESPACE | awk 'END{print $1}')
+
+          # Delete all volumes
+          # NOTE: can't wait for this command since PVCs 
+          # can't be deleted while pods are running
+          kubectl delete pvc --all -n $NAMESPACE --wait=false
+
+          # Rollback to the same version, ensuring recreation of all PVCs
+          if [[ -n "$LATEST_REVISION" ]]; then
+            helm rollback ${{ secrets.RELESE_NAME }} $LATEST_REVISION -n $NAMESPACE
+          else
+            echo "No Helm release found to roll back."
+            exit 1
+          fi
+
+          # NOTE: this step might be redundant, but just to make sure
+          # We give it 1 minute to finish cleaning up
+          kubectl delete pods --all -n $NAMESPACE --timeout=60s
+          kubectl get pods -n $NAMESPACE
+
+      - name: Re-deploy GMP components
+        run: |
+          TODO: tc-cli deploy

--- a/.github/workflows/dispatch-reset-cluster.yaml
+++ b/.github/workflows/dispatch-reset-cluster.yaml
@@ -53,5 +53,9 @@ jobs:
           kubectl get pods -n $NAMESPACE
 
       - name: Re-deploy GMP components
-        run: |
-          TODO: tc-cli deploy
+        uses: ./.github/actions/tc-cli
+        with:
+          environment: ${{ github.event.inputs.environment }}
+          version: "latest"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: deploy


### PR DESCRIPTION
## Description

This PR adds a workflow which reset the development timechain (including chronicles, GRPC nodes and validators). The workflow is tested separately with a local cluster (except the `tc-cli deploy` step which requires it to be merged since it's a local action).

Closes #1518 