### PR TITLE
[tc-cli] handle admin acc funding error better

### DIFF
--- a/gmp/evm/src/lib.rs
+++ b/gmp/evm/src/lib.rs
@@ -405,7 +405,13 @@ impl IChain for Connector {
 	}
 	/// Uses a faucet to fund the account when possible.
 	async fn faucet(&self, balance: u128) -> Result<()> {
-		self.wallet.faucet(balance, None).await?;
+		match self.network_id() {
+			2 | 3 | 6 => {
+				let _ = self.wallet.faucet(balance, None).await?;
+			},
+			network_id => tracing::warn!("network {network_id} doesn't support faucet"),
+		}
+
 		Ok(())
 	}
 	/// Transfers an amount to an account.


### PR DESCRIPTION
fixes https://github.com/Analog-Labs/timechain/issues/1604

currently `tc-cli deploy` fails when `!admin_funds.is_zero()` in config and the network doesn't support faucet

