### PR TITLE
ci: fix build path trigger for tc-cli

### DIFF
--- a/.github/workflows/merge-docker-tc-cli.yaml
+++ b/.github/workflows/merge-docker-tc-cli.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - '.github/workflows/merge-docker-tc-cli.yaml'
       - 'analog-gmp/**'
-      - 'config/subxt/**'
+      - 'config/envs/**'
       - 'primitives/**'
       - 'tc-subxt/**'
       - 'tc-cli/**'

--- a/.github/workflows/pr-test-compose.yaml
+++ b/.github/workflows/pr-test-compose.yaml
@@ -58,6 +58,7 @@ jobs:
         run: |
           ${{ steps.tc-cli.outputs.TC_CLI }} smoke-test 2 3
       - name: Set up AWS credentials
+        if: ${{ always() }}
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.LOG_UPLOADER_KEY_ID }}


### PR DESCRIPTION
## Description

Changes in the env configurations weren't reflecting tc-cli rebuilds and since the configurations are copied to the container, this needs to happen when envs change.