### PR TITLE
ci: separate docker compose runs by run ID

### DIFF
--- a/.github/workflows/pr-test-compose.yaml
+++ b/.github/workflows/pr-test-compose.yaml
@@ -33,7 +33,7 @@ jobs:
         id: tc-cli
         run: |
           cat << EOF >> $GITHUB_OUTPUT
-          TC_CLI=docker compose run --rm --remove-orphans \
+          TC_CLI=docker compose -p $GITHUB_RUN_ID run --rm --remove-orphans \
             --env="TIMECHAIN_MNEMONIC=${{ secrets.TIMECHAIN_MNEMONIC }}" \
             --env="TARGET_MNEMONIC=${{ secrets.TARGET_MNEMONIC }}" \
             --env="TOKEN_PRICE_URL=${{ secrets.TOKEN_PRICE_URL }}" \
@@ -42,7 +42,7 @@ jobs:
           EOF
       - name: Setup containers
         run: |
-          docker compose --profile evm up -d
+          docker compose -p $GITHUB_RUN_ID --profile evm up -d
       - name: fetch prices
         run: |
           ${{ steps.tc-cli.outputs.TC_CLI }} fetch-prices
@@ -51,35 +51,16 @@ jobs:
           ${{ steps.tc-cli.outputs.TC_CLI }} smoke-test 2 3
       - name: Restart chronicles
         run: |
-          docker compose stop chronicle-2-evm chronicle-3-evm
+          docker compose -p $GITHUB_RUN_ID stop chronicle-2-evm chronicle-3-evm
           sleep 180s
-          docker compose start chronicle-2-evm chronicle-3-evm
+          docker compose -p $GITHUB_RUN_ID start chronicle-2-evm chronicle-3-evm
       - name: Still works
         run: |
           ${{ steps.tc-cli.outputs.TC_CLI }} smoke-test 2 3
-      - name: Set up AWS credentials
-        if: ${{ always() }}
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.LOG_UPLOADER_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.LOG_UPLOADER_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-        # Upload logs step collects all the logs from the containers
-        # and uploads it in a S3 bucket
-      - name: Upload logs
-        if: ${{ always() }}
-        run: |
-          mkdir -p logs
-          echo "Uploading container logs"
-          for container in $(docker compose ps --services); do
-            echo "Export logs for $container"
-            docker compose logs "$container" > "logs/$container.log"
-          done
-          aws s3 cp logs "s3://${BUCKET_NAME}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" --recursive
       - name: Cleanup
         if: ${{ always() }}
         run: |
-          docker compose --profile "*" down --remove-orphans
+          docker compose -p $GITHUB_RUN_ID --profile "*" down --remove-orphans
       - name: Cleanup working dir
         if: ${{ always() }}
         uses: eviden-actions/clean-self-hosted-runner@v1


### PR DESCRIPTION
## Description

This PR changes the way logs are extracted and saved from the integration test steps. The prior solution used S3 buckets, which had the issue of not capturing logs before the `Upload logs` step (container didn't even start, early errors, etc.).

This solution has a prerequisite - a promtail instance needs to run on the self-hosted runner (we can always add the step in the CI if this doesn't perform well). The promtail config looks something like this:

```
server:
  log_level: info
clients:
  - url: LOKI_URL
positions:
  filename: /tmp/positions.yaml

scrape_configs:
  - job_name: docker
    docker_sd_configs:
      - host: unix:///var/run/docker.sock
        refresh_interval: 5s
    pipeline_stages:
      - static_labels:
          job: compose-test-logs
    relabel_configs:
      - source_labels: [__meta_docker_container_id]
        target_label: container_id
      - source_labels: [__meta_docker_container_name]
        target_label: container_name
      - source_labels: [__meta_docker_container_label_com_docker_compose_project]
        target_label: run_id
```

By running the docker compose services specifying the `project` (`-p` flag) with the value of  workflow run ID, promtail translates it to a `run_id` label for querying the exact run. It looks something like this:
![image](https://github.com/user-attachments/assets/b982505d-0f68-4959-866b-7d5ce660c288)

The above image captures logs from containers running in this PR (run ID 13584257927).

LogQL query would be: `{job="compose-test-logs", run_id="13584257927"}`