### PR TITLE
envs: fix chronicle URLs to point to local DNS names

### DIFF
--- a/config/envs/local/config.yaml
+++ b/config/envs/local/config.yaml
@@ -82,7 +82,7 @@ networks:
     shard_size: 1
     shard_threshold: 1
 chronicles:
-  - http://timechain-chronicle-0-grpc-1:8080
-  - http://timechain-chronicle-1-grpc-1:8080
-  - http://timechain-chronicle-2-evm-1:8080
-  - http://timechain-chronicle-3-evm-1:8080
+  - http://chronicle-0-grpc:8080
+  - http://chronicle-1-grpc:8080
+  - http://chronicle-2-evm:8080
+  - http://chronicle-3-evm:8080

--- a/config/envs/local/local-evm.yaml
+++ b/config/envs/local/local-evm.yaml
@@ -44,5 +44,5 @@ networks:
     shard_size: 1
     shard_threshold: 1
 chronicles: 
-  - http://timechain-chronicle-2-evm-1:8080
-  - http://timechain-chronicle-3-evm-1:8080
+  - http://chronicle-2-evm:8080
+  - http://chronicle-3-evm:8080

--- a/config/envs/local/local-grpc-tss.yaml
+++ b/config/envs/local/local-grpc-tss.yaml
@@ -48,9 +48,9 @@ networks:
     shard_size: 3
     shard_threshold: 2
 chronicles: 
-  - http://timechain-chronicle-0-grpc-1:8080
-  - http://timechain-chronicle-0-grpc-2:8080
-  - http://timechain-chronicle-0-grpc-3:8080
-  - http://timechain-chronicle-1-grpc-1:8080
-  - http://timechain-chronicle-1-grpc-2:8080
-  - http://timechain-chronicle-1-grpc-3:8080
+  - http://chronicle-0-grpc:8080
+  - http://chronicle-0-grpc:8080
+  - http://chronicle-0-grpc:8080
+  - http://chronicle-1-grpc:8080
+  - http://chronicle-1-grpc:8080
+  - http://chronicle-1-grpc:8080

--- a/config/envs/local/local-grpc-tss.yaml
+++ b/config/envs/local/local-grpc-tss.yaml
@@ -48,9 +48,9 @@ networks:
     shard_size: 3
     shard_threshold: 2
 chronicles: 
-  - http://chronicle-0-grpc:8080
-  - http://chronicle-0-grpc:8080
-  - http://chronicle-0-grpc:8080
-  - http://chronicle-1-grpc:8080
-  - http://chronicle-1-grpc:8080
-  - http://chronicle-1-grpc:8080
+  - http://timechain-chronicle-0-grpc-1:8080
+  - http://timechain-chronicle-0-grpc-2:8080
+  - http://timechain-chronicle-0-grpc-3:8080
+  - http://timechain-chronicle-1-grpc-1:8080
+  - http://timechain-chronicle-1-grpc-2:8080
+  - http://timechain-chronicle-1-grpc-3:8080

--- a/config/envs/local/local-grpc.yaml
+++ b/config/envs/local/local-grpc.yaml
@@ -48,5 +48,5 @@ networks:
     shard_size: 1
     shard_threshold: 1
 chronicles: 
-  - http://timechain-chronicle-0-grpc-1:8080
-  - http://timechain-chronicle-1-grpc-1:8080
+  - http://chronicle-0-grpc:8080
+  - http://chronicle-1-grpc:8080


### PR DESCRIPTION
## Description

This PR fixes the `waiting for chronicle` CI error. The chronicles URLs were FQDNs, including the network and replica. Since [THIS](https://github.com/Analog-Labs/timechain/pull/1620) PR adds project for every run, the FQDN are dynamic and change per run, so can't really use them like that anymore. Instead, now it's pointing to local hostnames (local in it's network is more correct), so it won't affect anything outside the network.

**NOTE**: Don't merge this PR until every CI passes, need to have a stable checkpoint