### PR TITLE
ci: tag tc-cli image after runtime upgrade

### DIFF
--- a/.github/actions/build-contracts/action.yaml
+++ b/.github/actions/build-contracts/action.yaml
@@ -1,0 +1,47 @@
+name: "Install dependencies and build GMP contracts"
+description: "Action to install all tc-cli deps and build contracts"
+
+inputs:
+  version:
+    description: "Docker image version tag"
+    required: true
+    default: "dev"
+  token:
+    description: "Github API Token"
+    required: true
+  environment:
+    description: "Target env for the tc-cli dispatch"
+    required: true
+  args:
+    description: "Tc-cli arguments"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Cargo
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+        target: x86_64-unknown-linux-musl,wasm32-unknown-unknown
+        components: rust-src
+    - name: Install musl deps
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y musl-tools
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@v1
+    - name: Build contracts
+      shell: bash
+      run: forge build --root analog-gmp --optimize --optimizer-runs=200000 --evm-version=shanghai --use=0.8.25 --force
+    # At the moment mainnet doesn't support GMP, so the only compatible metadata is the testnet one
+    - name: Build tc-cli
+      shell: bash
+      run: cargo build --profile testnet -p tc-cli --target x86_64-unknown-linux-musl --features testnet,develop
+    - name: Prepare context
+      shell: bash
+      run: |
+        mkdir docker
+        cp target/x86_64-unknown-linux-musl/testnet/tc-cli docker/tc-cli
+        cp -rL config/envs docker/envs

--- a/.github/actions/build-contracts/action.yaml
+++ b/.github/actions/build-contracts/action.yaml
@@ -45,3 +45,4 @@ runs:
         mkdir docker
         cp target/x86_64-unknown-linux-musl/testnet/tc-cli docker/tc-cli
         cp -rL config/envs docker/envs
+        cp -rL analog-gmp docker/analog-gmp

--- a/.github/workflows/merge-docker-tc-cli.yaml
+++ b/.github/workflows/merge-docker-tc-cli.yaml
@@ -44,28 +44,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Setup Cargo
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-          target: x86_64-unknown-linux-musl,wasm32-unknown-unknown
-          components: rust-src
-      - name: Install musl deps
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-      - name: Build contracts
-        run: forge build --root analog-gmp --optimize --optimizer-runs=200000 --evm-version=shanghai --use=0.8.25 --force
-      # At the moment mainnet doesn't support GMP, so the only compatible metadata is the testnet one
-      - name: Build tc-cli
-        run: cargo build --profile testnet -p tc-cli --target x86_64-unknown-linux-musl --features testnet,develop
-      - name: Prepare context
-        run: |
-          mkdir docker
-          cp target/x86_64-unknown-linux-musl/testnet/tc-cli docker/tc-cli
-          cp -rL config/envs docker/envs
+      - name: Setup foundry and build GMP contracts
+        uses: ./.github/actions/build-contracts
       - name: Build and push
         uses: ./.github/actions/buildah-action
         with:

--- a/.github/workflows/merge-srtool-runtime.yaml
+++ b/.github/workflows/merge-srtool-runtime.yaml
@@ -144,7 +144,6 @@ jobs:
           -e TARGET_MNEMONIC="${{ secrets.TARGET_MNEMONIC }}" \
           ${{ needs.set_tags.outputs.tc_cli }} \
           --config /etc/config.yaml runtime-upgrade /etc/development-runtime.wasm
-
     - name: Notify on slack
       uses: slackapi/slack-github-action@v2.0.0
       with:
@@ -154,3 +153,16 @@ jobs:
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           thread_ts: ${{ github.event.inputs.thread }}
           text: "runtime upgrade from ${{ needs.set_tags.outputs.commit_hash8 }}"
+    - name: Setup foundry and build GMP contracts
+      uses: ./.github/actions/build-contracts
+    - name: Build tc-cli OCI image and push
+      uses: ./.github/actions/buildah-action
+      with:
+        image_name: ${{ env.TC_CLI_IMAGE }}
+        containerfile: ./config/docker/Dockerfile.tc-cli-release
+        context: docker
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        registry: docker.io
+        push: 'true'
+        tags: ${{ github.event.inputs.environment }}

--- a/config/docker/Dockerfile.tc-cli-release
+++ b/config/docker/Dockerfile.tc-cli-release
@@ -1,12 +1,14 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 WORKDIR /app
 
 COPY tc-cli tc-cli
 COPY envs /etc/envs
+COPY analog-gmp /analog-gmp
 
 RUN apt update && apt install -y wget
 
 RUN wget -O /app/foundry.tar.gz https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_amd64.tar.gz
 RUN tar -xvzf /app/foundry.tar.gz -C /usr/local/bin
 
+ENV ANALOG_GMP_DIR=/analog-gmp
 ENTRYPOINT ["/app/tc-cli"]


### PR DESCRIPTION
## Description

This PR builds and pushes a tc-cli OCI image after a runtime upgrade. The image is tagged with the environment where the runtime upgrade was done (development, integration, etc.). In this way after a runtime upgrade has been done, the tc-cli latest environment image should be inline with the chain's metadata.

Closes #1561 