### PR TITLE
Make draining transactions feeless

### DIFF
--- a/pallets/members/src/lib.rs
+++ b/pallets/members/src/lib.rs
@@ -170,6 +170,8 @@ pub mod pallet {
 		NotStaker,
 		/// Already registered
 		StillStaked,
+		/// Already submitted heartbeat
+		AlreadySubmittedHeartbeat,
 	}
 
 	/// Implements hooks for pallet initialization and block processing.
@@ -310,6 +312,7 @@ pub mod pallet {
 			Ok(())
 		}
 		fn execute_send_heartbeat(member: AccountId) -> DispatchResult {
+			ensure!(Heartbeat::<T>::get(&member).is_none(), Error::<T>::AlreadySubmittedHeartbeat);
 			ensure!(
 				MemberStake::<T>::get(&member) >= T::MinStake::get(),
 				Error::<T>::BondBelowMinStake

--- a/pallets/members/src/lib.rs
+++ b/pallets/members/src/lib.rs
@@ -170,8 +170,6 @@ pub mod pallet {
 		NotStaker,
 		/// Already registered
 		StillStaked,
-		/// Already submitted heartbeat
-		AlreadySubmittedHeartbeat,
 	}
 
 	/// Implements hooks for pallet initialization and block processing.
@@ -312,7 +310,6 @@ pub mod pallet {
 			Ok(())
 		}
 		fn execute_send_heartbeat(member: AccountId) -> DispatchResult {
-			ensure!(Heartbeat::<T>::get(&member).is_none(), Error::<T>::AlreadySubmittedHeartbeat);
 			ensure!(
 				MemberStake::<T>::get(&member) >= T::MinStake::get(),
 				Error::<T>::BondBelowMinStake

--- a/pallets/members/src/lib.rs
+++ b/pallets/members/src/lib.rs
@@ -241,7 +241,11 @@ pub mod pallet {
 		///		1. If not online, calls `Self::member_online` to mark them as online.
 		///	7. Returns `Ok(())` if successful.
 		#[pallet::call_index(2)]
-		#[pallet::weight((<T as Config>::WeightInfo::send_heartbeat(), DispatchClass::Operational))]
+		#[pallet::weight((
+			<T as Config>::WeightInfo::send_heartbeat(),
+			DispatchClass::Operational,
+			Pays::No
+		))]
 		pub fn send_heartbeat(origin: OriginFor<T>) -> DispatchResult {
 			let member = ensure_signed(origin)?;
 			Self::execute_send_heartbeat(member)

--- a/pallets/members/src/tests.rs
+++ b/pallets/members/src/tests.rs
@@ -92,7 +92,6 @@ fn send_heartbeat_works() {
 		assert_ok!(register_member(a.clone(), A, 5));
 		roll_to(5);
 		assert_ok!(send_heartbeat(A));
-		assert_ok!(send_heartbeat(A));
 		System::assert_last_event(Event::<Test>::HeartbeatReceived(a.clone()).into());
 		assert!(MemberOnline::<Test>::get(&a).is_some());
 		assert!(Heartbeat::<Test>::get(&a).is_some());

--- a/pallets/shards/src/lib.rs
+++ b/pallets/shards/src/lib.rs
@@ -253,7 +253,11 @@ pub mod pallet {
 		///   6. If all members have committed, update the state of the shards to `Committed` and store the group commitment.
 		///   7. Emit the [`Event::ShardCommitted`] event.
 		#[pallet::call_index(0)]
-		#[pallet::weight(<T as Config>::WeightInfo::commit())]
+		#[pallet::weight((
+			<T as Config>::WeightInfo::commit(),
+			DispatchClass::Normal,
+			Pays::No
+		))]
 		pub fn commit(
 			origin: OriginFor<T>,
 			shard_id: ShardId,
@@ -273,7 +277,11 @@ pub mod pallet {
 		///   4. If all members are ready, update the state of the shard to `Online` and emit the [`Event::ShardOnline`] event.
 		///   5. Notify the task scheduler that the shard is online.
 		#[pallet::call_index(1)]
-		#[pallet::weight(<T as Config>::WeightInfo::ready())]
+		#[pallet::weight((
+			<T as Config>::WeightInfo::ready(),
+			DispatchClass::Normal,
+			Pays::No
+		))]
 		pub fn ready(origin: OriginFor<T>, shard_id: ShardId) -> DispatchResult {
 			let member = ensure_signed(origin)?;
 			Self::execute_ready(member, shard_id)

--- a/pallets/tasks/src/lib.rs
+++ b/pallets/tasks/src/lib.rs
@@ -340,7 +340,11 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Used by chroncles to submit task results.
 		#[pallet::call_index(1)]
-		#[pallet::weight(<T as Config>::WeightInfo::submit_task_result())]
+		#[pallet::weight((
+			<T as Config>::WeightInfo::submit_task_result(),
+			DispatchClass::Normal,
+			Pays::No
+		))]
 		pub fn submit_task_result(
 			origin: OriginFor<T>,
 			task_id: TaskId,


### PR DESCRIPTION
Closes https://github.com/Analog-Labs/timechain/issues/1641

Caller does not pay fees for the following transactions but weight is still tracked the same way as before.
- [x] send_heartbeat
- [x] commit
- [x] ready
- [x] submit_task_result

More ways to implement feeless transactions discussed in more detail [here](https://substrate.stackexchange.com/questions/1713/how-we-can-implement-gasless-feeless-transaction)


Follow up: #1673