### PR TITLE
chronicle: remove filter for INFO logs

### DIFF
--- a/chronicle/src/lib.rs
+++ b/chronicle/src/lib.rs
@@ -52,6 +52,9 @@ pub fn init_opentelemetry() {
 		.with_ansi(false)
 		.with_file(true)
 		.with_line_number(true);
+	let filter_layer = EnvFilter::try_from_default_env()
+		.or_else(|_| EnvFilter::try_new("debug"))
+		.unwrap();
 
 	// Skip initializing OTLP if endpoint isn't given
 	if let Ok(endpoint) = std::env::var("TRACING_ENDPOINT") {
@@ -70,7 +73,7 @@ pub fn init_opentelemetry() {
 
 		let tracer = tracer_provider.tracer("tracing-otel-subscriber");
 		tracing_subscriber::registry()
-			.with(LevelFilter::from_level(Level::DEBUG))
+			.with(filter_layer)
 			.with(log_subscriber)
 			.with(OpenTelemetryLayer::new(tracer))
 			.init();
@@ -79,7 +82,12 @@ pub fn init_opentelemetry() {
 			.add_directive("chronicle=debug".parse().unwrap())
 			.add_directive("tss=debug".parse().unwrap())
 			.add_directive("peernet=debug".parse().unwrap());
-		tracing_subscriber::registry().with(log_subscriber).with(filter).try_init().ok();
+		tracing_subscriber::registry()
+			.with(filter_layer)
+			.with(log_subscriber)
+			.with(filter)
+			.try_init()
+			.ok();
 	}
 	std::panic::set_hook(Box::new(tracing_panic::panic_hook));
 }

--- a/chronicle/src/lib.rs
+++ b/chronicle/src/lib.rs
@@ -22,7 +22,7 @@ use opentelemetry_sdk::{
 };
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{
-	filter::{EnvFilter, LevelFilter},
+	filter::EnvFilter,
 	layer::SubscriberExt,
 	util::SubscriberInitExt,
 };

--- a/chronicle/src/lib.rs
+++ b/chronicle/src/lib.rs
@@ -79,11 +79,7 @@ pub fn init_opentelemetry() {
 			.add_directive("chronicle=debug".parse().unwrap())
 			.add_directive("tss=debug".parse().unwrap())
 			.add_directive("peernet=debug".parse().unwrap());
-		tracing_subscriber::registry()
-			.with(log_subscriber)
-			.with(filter)
-			.try_init()
-			.ok();
+		tracing_subscriber::registry().with(log_subscriber).with(filter).try_init().ok();
 	}
 	std::panic::set_hook(Box::new(tracing_panic::panic_hook));
 }

--- a/chronicle/src/lib.rs
+++ b/chronicle/src/lib.rs
@@ -80,7 +80,6 @@ pub fn init_opentelemetry() {
 			.add_directive("tss=debug".parse().unwrap())
 			.add_directive("peernet=debug".parse().unwrap());
 		tracing_subscriber::registry()
-			.with(LevelFilter::INFO)
 			.with(log_subscriber)
 			.with(filter)
 			.try_init()

--- a/chronicle/src/lib.rs
+++ b/chronicle/src/lib.rs
@@ -21,11 +21,7 @@ use opentelemetry_sdk::{
 	Resource,
 };
 use tracing_opentelemetry::OpenTelemetryLayer;
-use tracing_subscriber::{
-	filter::EnvFilter,
-	layer::SubscriberExt,
-	util::SubscriberInitExt,
-};
+use tracing_subscriber::{filter::EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 pub mod admin;
 #[cfg(test)]


### PR DESCRIPTION
## Description

We're missing debug logs on the chronicles, our assumption is the level filter filters out everything up to INFO level.

Closes #1694 