### PR TITLE
staking: repeat missed events in migration

### DIFF
--- a/.github/workflows/pr-test-try_runtime.yaml
+++ b/.github/workflows/pr-test-try_runtime.yaml
@@ -37,4 +37,4 @@ jobs:
       - name: Download current snapshot
         run: curl -LO https://analog-public.s3.amazonaws.com/state-snapshot/${{ matrix.chain }}-state.snap
       - name: Run try-runtime test
-        run: try-runtime --runtime target/release/wbuild/timechain-runtime/timechain_runtime.wasm on-runtime-upgrade --blocktime 6000 --checks all --disable-spec-version-check --disable-idempotency-checks snap --path ${{ matrix.chain }}-state.snap
+        run: try-runtime --runtime target/release/wbuild/timechain-runtime/timechain_runtime.wasm on-runtime-upgrade --blocktime 6000 --checks all --disable-spec-version-check --disable-idempotency-checks --disable-mbm-checks snap --path ${{ matrix.chain }}-state.snap

--- a/runtime/src/configs/staking.rs
+++ b/runtime/src/configs/staking.rs
@@ -22,6 +22,7 @@ use sp_runtime::{
 	curve::PiecewiseLinear, traits::AccountIdConversion, transaction_validity::TransactionPriority,
 	FixedU128, Perbill, Percent,
 };
+use sp_staking::OnStakingUpdate;
 use sp_std::prelude::*;
 
 use pallet_election_provider_multi_phase::{GeometricDepositBase, SolutionAccuracyOf};
@@ -401,6 +402,42 @@ impl pallet_delegated_staking::Config for Runtime {
 	type SlashRewardFraction = SlashRewardFraction;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type CoreStaking = Staking;
+}
+pub struct RepeatMissedStakingEvents<T>(sp_std::marker::PhantomData<T>);
+
+#[cfg(not(feature = "develop"))]
+const MISSED_WITHDRAWS: &[u128] = &[431292290133226741, 1604142936180618865, 223849342984982840];
+
+#[cfg(feature = "develop")]
+const MISSED_WITHDRAWS: &[u128] =
+	&[28400000000000, 10042916949407405590, 19334200000000, 11201100000000];
+
+const POOL_STAKER: AccountId = AccountId::new(sp_core::hex2array!(
+	"6d6f646c74696d656e6d706c0001000000000000000000000000000000000000"
+));
+
+impl<T: frame_system::Config + pallet_delegated_staking::Config>
+	frame_support::traits::OnRuntimeUpgrade for RepeatMissedStakingEvents<T>
+{
+	fn on_runtime_upgrade() -> Weight {
+		// Wrap storage migration indside transactions that reverts on failure
+		if let Err(error) = frame_support::storage::with_storage_layer(|| {
+			let mut total = 0;
+
+			for amount in MISSED_WITHDRAWS {
+				DelegatedStaking::on_withdraw(&POOL_STAKER, *amount);
+				total += *amount;
+			}
+
+			log::info!("🎱 Total amount repeated: {total}");
+
+			Ok::<(), &str>(())
+		}) {
+			log::error!("🎱 Migration failed: {error}");
+		}
+
+		Weight::zero()
+	}
 }
 
 #[cfg(test)]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -106,6 +106,7 @@ pub use configs::core::{
 #[cfg(feature = "testnet")]
 pub use configs::custom::PrevalidateFeeless;
 pub use configs::governance::DefaultAdminOrigin;
+pub use configs::staking::RepeatMissedStakingEvents;
 pub use configs::tokenomics::{ExistentialDeposit, LengthToFee, WeightToFee};
 
 /// Import variant constants and macros
@@ -626,7 +627,7 @@ mod runtime {
 }
 
 // All migrations executed on runtime upgrade implementing `OnRuntimeUpgrade`.
-type Migrations = ();
+type Migrations = RepeatMissedStakingEvents<Runtime>;
 
 #[cfg(test)]
 mod core_tests {


### PR DESCRIPTION
Attempt at executing the bindings of missed events.

- [x] Add staging data (indexer is running...)
- [x]  Run internal test at end to ensure consistency (try-runtime)