### PR TITLE
chronicle: enter parent spans when in different thread

### DIFF
--- a/chronicle/src/shards/service.rs
+++ b/chronicle/src/shards/service.rs
@@ -414,6 +414,7 @@ where
 					}
 				},
 				notification = finality_notifications.next().fuse() => {
+					let _enter = span.enter();
 					let Some((block_hash, block)) = notification else {
 						event!(
 							parent: span,
@@ -432,6 +433,7 @@ where
 					}
 				},
 				tss_request = self.tss_request.next().fuse() => {
+					let _enter = span.enter();
 					let Some(TssSigningRequest { task_id, shard_id, data, tx, block }) = tss_request else {
 						continue;
 					};

--- a/chronicle/src/shards/service.rs
+++ b/chronicle/src/shards/service.rs
@@ -373,6 +373,7 @@ where
 		loop {
 			futures::select! {
 				notification = block_notifications.next().fuse() => {
+					let _enter = span.enter();
 					let Some((_block_hash, block)) = notification else {
 						event!(
 							parent: span,


### PR DESCRIPTION
## Description

This PR fixes missing parent context when entering different threads.

Logs before:
```
INFO tss: no signing session
    at tss/src/lib.rs:275
    in tss::session with session: 3363
    in tss::on_message with from: tzwffgyw773clqrtqgmd3wotfbq3zfqnifo7csifwfp3nlvyd4pq, msg: roast 3363 commit     in tss::tss with peer_id: kvl2e4ktxle5z5n5ejqtl7wmfauryori4t7eorj3aavj53255y2a
```

Logs in this PR:
```
2025-03-20T08:50:07.565773Z  INFO tss: no signing session
    at tss/src/lib.rs:275
    in tss::session with session: 4
    in tss::on_message with from: kph36htr3hkdra4gc6c6ynkviylfvhq6b7kyj4qfasxipda7mwbq, msg: roast 4 commit
    in tss::tss with peer_id: nmpz5gdrgekyttv62i2ykbbdpxadlcu42wwbenh56z7b234z5yzq
    in chronicle::shards::service::join shard with shard_id: 1
    in chronicle::shards::service::on_finality with block: 19, block_hash: "0xb16bbbff839d2a2de7017fd7bbba5f5b1f7c27159a96322de99e39ed729f256c"
    in chronicle::chronicle with timechain: "azsPLbjmxDYbtr1bxxLtEet7ik3pPkkJYaSaaW1bSawCNxHDu", target: "204418730198be91f72d6ae4fb0c62153285b38b4096e801ebf37e5a8611360f", peer_id: "nmpz5gdrgekyttv62i2ykbbdpxadlcu42wwbenh56z7b234z5yzq"

```
Closes #1710 