### PR TITLE
staking: remove missed events migration

### DIFF
--- a/runtime/src/configs/staking.rs
+++ b/runtime/src/configs/staking.rs
@@ -22,7 +22,6 @@ use sp_runtime::{
 	curve::PiecewiseLinear, traits::AccountIdConversion, transaction_validity::TransactionPriority,
 	FixedU128, Perbill, Percent,
 };
-use sp_staking::OnStakingUpdate;
 use sp_std::prelude::*;
 
 use pallet_election_provider_multi_phase::{GeometricDepositBase, SolutionAccuracyOf};
@@ -402,42 +401,6 @@ impl pallet_delegated_staking::Config for Runtime {
 	type SlashRewardFraction = SlashRewardFraction;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type CoreStaking = Staking;
-}
-pub struct RepeatMissedStakingEvents<T>(sp_std::marker::PhantomData<T>);
-
-#[cfg(not(feature = "develop"))]
-const MISSED_WITHDRAWS: &[u128] = &[431292290133226741, 1604142936180618865, 223849342984982840];
-
-#[cfg(feature = "develop")]
-const MISSED_WITHDRAWS: &[u128] =
-	&[28400000000000, 10042916949407405590, 19334200000000, 11201100000000];
-
-const POOL_STAKER: AccountId = AccountId::new(sp_core::hex2array!(
-	"6d6f646c74696d656e6d706c0001000000000000000000000000000000000000"
-));
-
-impl<T: frame_system::Config + pallet_delegated_staking::Config>
-	frame_support::traits::OnRuntimeUpgrade for RepeatMissedStakingEvents<T>
-{
-	fn on_runtime_upgrade() -> Weight {
-		// Wrap storage migration indside transactions that reverts on failure
-		if let Err(error) = frame_support::storage::with_storage_layer(|| {
-			let mut total = 0;
-
-			for amount in MISSED_WITHDRAWS {
-				DelegatedStaking::on_withdraw(&POOL_STAKER, *amount);
-				total += *amount;
-			}
-
-			log::info!("🎱 Total amount repeated: {total}");
-
-			Ok::<(), &str>(())
-		}) {
-			log::error!("🎱 Migration failed: {error}");
-		}
-
-		Weight::zero()
-	}
 }
 
 #[cfg(test)]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -106,7 +106,6 @@ pub use configs::core::{
 #[cfg(feature = "testnet")]
 pub use configs::custom::PrevalidateFeeless;
 pub use configs::governance::DefaultAdminOrigin;
-pub use configs::staking::RepeatMissedStakingEvents;
 pub use configs::tokenomics::{ExistentialDeposit, LengthToFee, WeightToFee};
 
 /// Import variant constants and macros
@@ -627,7 +626,7 @@ mod runtime {
 }
 
 // All migrations executed on runtime upgrade implementing `OnRuntimeUpgrade`.
-type Migrations = RepeatMissedStakingEvents<Runtime>;
+type Migrations = ();
 
 #[cfg(test)]
 mod core_tests {


### PR DESCRIPTION
This removes the staking fix migration again so it is not accidentally run on one of our other environments.