### PR TITLE
polkadot-sdk: update to v1.16

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
-
-[target.x86_64-unknown-linux-musl]
-rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]

--- a/.github/workflows/merge-docker-timenode.yaml
+++ b/.github/workflows/merge-docker-timenode.yaml
@@ -36,9 +36,6 @@ jobs:
           - image: prod
             profile: mainnet
             features: default
-          - image: bridge
-            profile: mainnet
-            features: bridge
           - image: staging
             profile: mainnet
             features: develop

--- a/.github/workflows/merge-srtool-runtime.yaml
+++ b/.github/workflows/merge-srtool-runtime.yaml
@@ -93,12 +93,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Build timechain runtime
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.9.2
+        uses: chevdor/srtool-actions@v0.9.0
         env:
           BUILD_OPTS: --features ${{ matrix.features }}
         with:
           image: analoglabs/srtool
-          tag: 1.79.0
+          tag: 1.85.1
           chain: timechain
           runtime_dir: runtime
       - name: Srtool summary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21318,7 +21318,6 @@ dependencies = [
  "clap_complete",
  "convert_case 0.8.0",
  "deranged",
- "eth-bridge",
  "futures",
  "hex-literal 1.0.0",
  "jsonrpsee",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "always-assert"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4436e0292ab1bb631b42973c61205e704475fe8126af845c8d923c0996328127"
+
+[[package]]
 name = "analog-docs"
 version = "0.8.0"
 dependencies = [
@@ -942,15 +948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -1473,8 +1470,8 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "asset-test-utils"
-version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "20.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -1504,14 +1501,15 @@ dependencies = [
 
 [[package]]
 name = "assets-common"
-version = "0.17.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.3"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
  "impl-trait-for-tuples",
  "log",
  "pallet-asset-conversion",
+ "pallet-assets",
  "pallet-xcm",
  "parachains-common",
  "parity-scale-codec",
@@ -1568,6 +1566,18 @@ dependencies = [
  "fastrand 2.3.0",
  "futures-lite 2.6.0",
  "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "blocking",
+ "futures-lite 1.13.0",
 ]
 
 [[package]]
@@ -1674,6 +1684,17 @@ dependencies = [
 
 [[package]]
 name = "async-net"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0434b1ed18ce1cf5769b8ac540e33f01fa9471058b5e89da9e06f3c882a8c12f"
+dependencies = [
+ "async-io 1.13.0",
+ "blocking",
+ "futures-lite 1.13.0",
+]
+
+[[package]]
+name = "async-net"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
@@ -1681,6 +1702,23 @@ dependencies = [
  "async-io 2.4.0",
  "blocking",
  "futures-lite 2.6.0",
+]
+
+[[package]]
+name = "async-process"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+dependencies = [
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 3.1.0",
+ "futures-lite 1.13.0",
+ "rustix 0.38.44",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1755,7 +1793,7 @@ dependencies = [
  "async-global-executor",
  "async-io 2.4.0",
  "async-lock 3.4.0",
- "async-process",
+ "async-process 2.3.0",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
@@ -2111,15 +2149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,8 +2156,8 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "binary-merkle-tree"
-version = "15.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "15.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "hash-db",
  "log",
@@ -2457,102 +2486,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "bp-asset-hub-rococo"
-version = "0.13.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
-dependencies = [
- "bp-xcm-bridge-hub-router",
- "frame-support",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
-name = "bp-asset-hub-westend"
-version = "0.12.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
-dependencies = [
- "bp-xcm-bridge-hub-router",
- "frame-support",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
-name = "bp-bridge-hub-cumulus"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
-dependencies = [
- "bp-messages",
- "bp-polkadot-core",
- "bp-runtime",
- "frame-support",
- "frame-system",
- "polkadot-primitives",
- "sp-api",
- "sp-std",
-]
-
-[[package]]
-name = "bp-bridge-hub-kusama"
-version = "0.16.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
-dependencies = [
- "bp-bridge-hub-cumulus",
- "bp-messages",
- "bp-runtime",
- "frame-support",
- "sp-api",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "bp-bridge-hub-polkadot"
-version = "0.16.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
-dependencies = [
- "bp-bridge-hub-cumulus",
- "bp-messages",
- "bp-runtime",
- "frame-support",
- "sp-api",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "bp-bridge-hub-rococo"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
-dependencies = [
- "bp-bridge-hub-cumulus",
- "bp-messages",
- "bp-runtime",
- "frame-support",
- "sp-api",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "bp-bridge-hub-westend"
-version = "0.13.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
-dependencies = [
- "bp-bridge-hub-cumulus",
- "bp-messages",
- "bp-runtime",
- "frame-support",
- "sp-api",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "bp-header-chain"
-version = "0.17.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -2567,22 +2503,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "bp-kusama"
-version = "0.15.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
-dependencies = [
- "bp-header-chain",
- "bp-polkadot-core",
- "bp-runtime",
- "frame-support",
- "sp-api",
- "sp-std",
-]
-
-[[package]]
 name = "bp-messages"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -2591,13 +2514,14 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
+ "sp-io",
  "sp-std",
 ]
 
 [[package]]
 name = "bp-parachains"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -2613,39 +2537,21 @@ dependencies = [
 
 [[package]]
 name = "bp-polkadot"
-version = "0.15.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std",
-]
-
-[[package]]
-name = "bp-polkadot-bulletin"
-version = "0.14.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
-dependencies = [
- "bp-header-chain",
- "bp-messages",
- "bp-polkadot-core",
- "bp-runtime",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
- "sp-runtime",
  "sp-std",
 ]
 
 [[package]]
 name = "bp-polkadot-core"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -2662,12 +2568,16 @@ dependencies = [
 
 [[package]]
 name = "bp-relayers"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
+ "bp-header-chain",
  "bp-messages",
+ "bp-parachains",
  "bp-runtime",
  "frame-support",
+ "frame-system",
+ "pallet-utility",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -2675,22 +2585,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "bp-rococo"
-version = "0.16.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
-dependencies = [
- "bp-header-chain",
- "bp-polkadot-core",
- "bp-runtime",
- "frame-support",
- "sp-api",
- "sp-std",
-]
-
-[[package]]
 name = "bp-runtime"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2712,8 +2609,8 @@ dependencies = [
 
 [[package]]
 name = "bp-test-utils"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -2731,41 +2628,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "bp-westend"
-version = "0.13.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+name = "bp-xcm-bridge-hub"
+version = "0.4.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
- "bp-header-chain",
- "bp-polkadot-core",
+ "bp-messages",
  "bp-runtime",
  "frame-support",
- "sp-api",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
  "sp-std",
-]
-
-[[package]]
-name = "bp-xcm-bridge-hub"
-version = "0.3.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
-dependencies = [
- "sp-std",
+ "staging-xcm",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.14.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.14.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
  "sp-runtime",
+ "staging-xcm",
 ]
 
 [[package]]
 name = "bridge-hub-common"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.10.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2775,22 +2669,23 @@ dependencies = [
  "snowbridge-core",
  "sp-core",
  "sp-runtime",
+ "sp-std",
  "staging-xcm",
 ]
 
 [[package]]
 name = "bridge-hub-test-utils"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.20.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
  "bp-messages",
+ "bp-parachains",
  "bp-polkadot-core",
  "bp-relayers",
  "bp-runtime",
  "bp-test-utils",
- "bridge-runtime-common",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
  "frame-support",
@@ -2804,6 +2699,8 @@ dependencies = [
  "pallet-bridge-relayers",
  "pallet-timestamp",
  "pallet-utility",
+ "pallet-xcm",
+ "pallet-xcm-bridge-hub",
  "parachains-common",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
@@ -2811,6 +2708,7 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-runtime",
+ "sp-std",
  "sp-tracing",
  "staging-xcm",
  "staging-xcm-builder",
@@ -2830,8 +2728,8 @@ dependencies = [
 
 [[package]]
 name = "bridge-runtime-common"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.3"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2839,8 +2737,6 @@ dependencies = [
  "bp-polkadot-core",
  "bp-relayers",
  "bp-runtime",
- "bp-xcm-bridge-hub",
- "bp-xcm-bridge-hub-router",
  "frame-support",
  "frame-system",
  "log",
@@ -2857,7 +2753,6 @@ dependencies = [
  "sp-std",
  "sp-trie",
  "staging-xcm",
- "staging-xcm-builder",
  "tuplex",
 ]
 
@@ -3341,6 +3236,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-print"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4"
+dependencies = [
+ "color-print-proc-macro",
+]
+
+[[package]]
+name = "color-print-proc-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692186b5ebe54007e45a59aea47ece9eb4108e141326c304cdc91699a7118a22"
+dependencies = [
+ "nom",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3567,6 +3483,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cpu-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3906,9 +3832,273 @@ dependencies = [
 ]
 
 [[package]]
-name = "cumulus-pallet-aura-ext"
+name = "cumulus-client-cli"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "clap",
+ "parity-scale-codec",
+ "sc-chain-spec",
+ "sc-cli",
+ "sc-client-api",
+ "sc-service",
+ "sp-blockchain",
+ "sp-core",
+ "sp-runtime",
+ "url",
+]
+
+[[package]]
+name = "cumulus-client-collator"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "cumulus-client-consensus-common",
+ "cumulus-client-network",
+ "cumulus-primitives-core",
+ "futures",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-overseer",
+ "polkadot-primitives",
+ "sc-client-api",
+ "sp-api",
+ "sp-consensus",
+ "sp-core",
+ "sp-runtime",
+ "tracing",
+]
+
+[[package]]
+name = "cumulus-client-consensus-aura"
+version = "0.18.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "async-trait",
+ "cumulus-client-collator",
+ "cumulus-client-consensus-common",
+ "cumulus-client-consensus-proposer",
+ "cumulus-client-parachain-inherent",
+ "cumulus-primitives-aura",
+ "cumulus-primitives-core",
+ "cumulus-relay-chain-interface",
+ "futures",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-overseer",
+ "polkadot-primitives",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-consensus-aura",
+ "sc-consensus-babe",
+ "sc-consensus-slots",
+ "sc-telemetry",
+ "sc-utils",
+ "schnellru",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-timestamp",
+ "substrate-prometheus-endpoint",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "cumulus-client-consensus-common"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "async-trait",
+ "cumulus-client-pov-recovery",
+ "cumulus-primitives-core",
+ "cumulus-relay-chain-interface",
+ "dyn-clone",
+ "futures",
+ "log",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-consensus-babe",
+ "schnellru",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-runtime",
+ "sp-timestamp",
+ "sp-trie",
+ "sp-version",
+ "substrate-prometheus-endpoint",
+ "tracing",
+]
+
+[[package]]
+name = "cumulus-client-consensus-proposer"
 version = "0.16.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cumulus-primitives-parachain-inherent",
+ "sp-consensus",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cumulus-client-consensus-relay-chain"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "async-trait",
+ "cumulus-client-consensus-common",
+ "cumulus-primitives-core",
+ "cumulus-relay-chain-interface",
+ "futures",
+ "parking_lot 0.12.3",
+ "sc-consensus",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "substrate-prometheus-endpoint",
+ "tracing",
+]
+
+[[package]]
+name = "cumulus-client-network"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "async-trait",
+ "cumulus-relay-chain-interface",
+ "futures",
+ "futures-timer",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "sc-client-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-version",
+ "tracing",
+]
+
+[[package]]
+name = "cumulus-client-parachain-inherent"
+version = "0.12.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "async-trait",
+ "cumulus-primitives-core",
+ "cumulus-primitives-parachain-inherent",
+ "cumulus-relay-chain-interface",
+ "cumulus-test-relay-sproof-builder",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sp-api",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-storage",
+ "sp-trie",
+ "tracing",
+]
+
+[[package]]
+name = "cumulus-client-pov-recovery"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "async-trait",
+ "cumulus-primitives-core",
+ "cumulus-relay-chain-interface",
+ "futures",
+ "futures-timer",
+ "parity-scale-codec",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-overseer",
+ "polkadot-primitives",
+ "rand 0.8.5",
+ "sc-client-api",
+ "sc-consensus",
+ "sp-api",
+ "sp-consensus",
+ "sp-maybe-compressed-blob",
+ "sp-runtime",
+ "sp-version",
+ "tracing",
+]
+
+[[package]]
+name = "cumulus-client-service"
+version = "0.19.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "cumulus-client-cli",
+ "cumulus-client-collator",
+ "cumulus-client-consensus-common",
+ "cumulus-client-network",
+ "cumulus-client-pov-recovery",
+ "cumulus-primitives-core",
+ "cumulus-primitives-proof-size-hostfunction",
+ "cumulus-relay-chain-inprocess-interface",
+ "cumulus-relay-chain-interface",
+ "cumulus-relay-chain-minimal-node",
+ "futures",
+ "polkadot-primitives",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-network",
+ "sc-network-sync",
+ "sc-network-transactions",
+ "sc-rpc",
+ "sc-service",
+ "sc-sysinfo",
+ "sc-telemetry",
+ "sc-transaction-pool",
+ "sc-utils",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-transaction-pool",
+]
+
+[[package]]
+name = "cumulus-pallet-aura-ext"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3924,8 +4114,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-dmp-queue"
-version = "0.16.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -3941,8 +4131,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.16.2"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.17.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -3978,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -3988,8 +4178,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
-version = "18.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "19.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4001,8 +4191,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-solo-to-para"
-version = "0.16.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -4016,8 +4206,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.16.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -4031,8 +4221,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.16.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.17.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -4056,8 +4246,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-ping"
-version = "0.16.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -4072,20 +4262,16 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
- "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-primitives",
  "sp-api",
  "sp-consensus-aura",
- "sp-runtime",
 ]
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.15.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -4100,8 +4286,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.15.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4109,15 +4295,13 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
  "sp-trie",
 ]
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -4126,8 +4310,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
-version = "7.0.2"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "8.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -4142,8 +4326,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-timestamp"
-version = "0.15.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -4152,8 +4336,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.16.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -4161,8 +4345,6 @@ dependencies = [
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
- "polkadot-runtime-parachains",
- "sp-io",
  "sp-runtime",
  "staging-xcm",
  "staging-xcm-builder",
@@ -4170,9 +4352,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-relay-chain-inprocess-interface"
+version = "0.19.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "async-trait",
+ "cumulus-primitives-core",
+ "cumulus-relay-chain-interface",
+ "futures",
+ "futures-timer",
+ "polkadot-cli",
+ "polkadot-service",
+ "sc-cli",
+ "sc-client-api",
+ "sc-sysinfo",
+ "sc-telemetry",
+ "sc-tracing",
+ "sp-api",
+ "sp-consensus",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+]
+
+[[package]]
+name = "cumulus-relay-chain-interface"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "async-trait",
+ "cumulus-primitives-core",
+ "futures",
+ "jsonrpsee-core",
+ "parity-scale-codec",
+ "polkadot-overseer",
+ "sc-client-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-state-machine",
+ "sp-version",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cumulus-relay-chain-minimal-node"
+version = "0.19.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "array-bytes",
+ "async-trait",
+ "cumulus-primitives-core",
+ "cumulus-relay-chain-interface",
+ "cumulus-relay-chain-rpc-interface",
+ "futures",
+ "polkadot-core-primitives",
+ "polkadot-network-bridge",
+ "polkadot-node-network-protocol",
+ "polkadot-node-subsystem-util",
+ "polkadot-overseer",
+ "polkadot-primitives",
+ "polkadot-service",
+ "sc-authority-discovery",
+ "sc-client-api",
+ "sc-network",
+ "sc-network-common",
+ "sc-service",
+ "sc-tracing",
+ "sc-utils",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-babe",
+ "sp-runtime",
+ "substrate-prometheus-endpoint",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "cumulus-relay-chain-rpc-interface"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "async-trait",
+ "cumulus-primitives-core",
+ "cumulus-relay-chain-interface",
+ "either",
+ "futures",
+ "futures-timer",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "pin-project",
+ "polkadot-overseer",
+ "rand 0.8.5",
+ "sc-client-api",
+ "sc-rpc-api",
+ "sc-service",
+ "schnellru",
+ "serde",
+ "serde_json",
+ "smoldot 0.11.0",
+ "smoldot-light 0.9.0",
+ "sp-api",
+ "sp-authority-discovery",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-storage",
+ "sp-version",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.15.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4209,6 +4508,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.4",
+ "subtle-ng",
+ "zeroize",
 ]
 
 [[package]]
@@ -5152,6 +5464,17 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite 0.2.16",
+]
+
+[[package]]
+name = "event-listener"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
@@ -5427,7 +5750,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -5459,8 +5782,8 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -5483,8 +5806,8 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "42.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "43.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -5533,8 +5856,8 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-pallet-pov"
-version = "27.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "28.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5562,7 +5885,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -5572,8 +5895,8 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-support"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5588,8 +5911,8 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5630,8 +5953,8 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata-hash-extension"
-version = "0.5.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.6.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "docify",
@@ -5645,8 +5968,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "37.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -5686,12 +6009,13 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "30.0.5"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "30.0.6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "Inflector",
  "cfg-expr",
  "derive-syn-parse",
+ "docify",
  "expander",
  "frame-support-procedural-tools",
  "itertools 0.11.0",
@@ -5699,14 +6023,14 @@ dependencies = [
  "proc-macro-warning 1.84.1",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.3.0",
@@ -5718,7 +6042,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5727,8 +6051,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "37.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5747,8 +6071,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5762,7 +6086,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -5771,8 +6095,8 @@ dependencies = [
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.43.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6065,8 +6389,8 @@ dependencies = [
 
 [[package]]
 name = "generate-bags"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "chrono",
  "frame-election-provider-support",
@@ -7797,28 +8121,18 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b089779ad7f80768693755a031cc14a7766aba707cbe886674e3f79e9b7e47"
-dependencies = [
- "jsonrpsee-core 0.23.2",
- "jsonrpsee-proc-macros",
- "jsonrpsee-server",
- "jsonrpsee-types 0.23.2",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee"
 version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b26c20e2178756451cfeb0661fb74c47dd5988cb7e3939de7e9241fd604d42"
 dependencies = [
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.24.9",
- "jsonrpsee-types 0.24.9",
+ "jsonrpsee-core",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-server",
+ "jsonrpsee-types",
  "jsonrpsee-ws-client",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -7830,12 +8144,12 @@ dependencies = [
  "base64 0.22.1",
  "futures-util",
  "http 1.3.1",
- "jsonrpsee-core 0.24.9",
+ "jsonrpsee-core",
  "pin-project",
  "rustls 0.23.25",
  "rustls-pki-types",
  "rustls-platform-verifier",
- "soketto",
+ "soketto 0.8.1",
  "thiserror 1.0.69",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -7846,40 +8160,21 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79712302e737d23ca0daa178e752c9334846b08321d439fd89af9a384f8c830b"
-dependencies = [
- "anyhow",
- "async-trait",
- "beef",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "jsonrpsee-types 0.23.2",
- "parking_lot 0.12.3",
- "rand 0.8.5",
- "rustc-hash 1.1.0",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-core"
 version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456196007ca3a14db478346f58c7238028d55ee15c1df15115596e411ff27925"
 dependencies = [
  "async-trait",
+ "bytes",
  "futures-timer",
  "futures-util",
- "jsonrpsee-types 0.24.9",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "jsonrpsee-types",
+ "parking_lot 0.12.3",
  "pin-project",
+ "rand 0.8.5",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -7891,9 +8186,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.23.2"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7895f186d5921065d96e16bd795e5ca89ac8356ec423fafc6e3d7cf8ec11aee4"
+checksum = "5e65763c942dfc9358146571911b0cd1c361c2d63e2d2305622d40d36376ca80"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate 3.3.0",
@@ -7904,43 +8199,29 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.23.2"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654afab2e92e5d88ebd8a39d6074483f3f2bfdf91c5ac57fe285e7127cdd4f51"
+checksum = "55e363146da18e50ad2b51a0a7925fc423137a0b1371af8235b1c231a0647328"
 dependencies = [
- "anyhow",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-util",
- "jsonrpsee-core 0.23.2",
- "jsonrpsee-types 0.23.2",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "pin-project",
  "route-recognizer 0.3.1",
  "serde",
  "serde_json",
- "soketto",
+ "soketto 0.8.1",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tower 0.4.13",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c465fbe385238e861fdc4d1c85e04ada6c1fd246161d26385c1b311724d2af"
-dependencies = [
- "beef",
- "http 1.3.1",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7963,8 +8244,8 @@ checksum = "01b3323d890aa384f12148e8d2a1fd18eb66e9e7e825f9de4fa53bcc19b93eef"
 dependencies = [
  "http 1.3.1",
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.24.9",
- "jsonrpsee-types 0.24.9",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "url",
 ]
 
@@ -8058,6 +8339,17 @@ dependencies = [
  "regex",
  "rocksdb",
  "smallvec",
+]
+
+[[package]]
+name = "landlock"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9baa9eeb6e315942429397e617a190f4fdc696ef1ee0342939d641029cbb4ea7"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8509,7 +8801,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite 0.2.16",
  "rw-stream-sink",
- "soketto",
+ "soketto 0.8.1",
  "thiserror 1.0.69",
  "url",
  "webpki-roots 0.25.4",
@@ -8802,6 +9094,12 @@ checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 dependencies = [
  "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "lru"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
 
 [[package]]
 name = "lru"
@@ -9117,8 +9415,8 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "40.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "futures",
  "log",
@@ -9136,10 +9434,10 @@ dependencies = [
 
 [[package]]
 name = "mmr-rpc"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "parity-scale-codec",
  "serde",
  "sp-api",
@@ -9574,6 +9872,18 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
  "libc",
 ]
 
@@ -10035,8 +10345,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-alliance"
-version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "frame-benchmarking",
@@ -10048,15 +10358,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "sp-io",
  "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-asset-conversion"
-version = "19.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "20.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10073,8 +10383,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-conversion-ops"
-version = "0.5.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.6.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10091,8 +10401,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
-version = "19.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "20.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10105,8 +10415,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-rate"
-version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10119,8 +10429,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10136,8 +10446,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets"
-version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "40.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10152,8 +10462,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets-freezer"
-version = "0.4.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.5.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10167,8 +10477,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-atomic-swap"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10181,8 +10491,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura"
-version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10197,8 +10507,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10212,8 +10522,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-authorship"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10225,8 +10535,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-babe"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10248,8 +10558,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bags-list"
-version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "aquamarine",
  "docify",
@@ -10269,8 +10579,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "38.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "39.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10284,8 +10594,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy"
-version = "38.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "39.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10303,11 +10613,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "38.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "39.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
@@ -10327,8 +10638,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bounties"
-version = "36.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10344,8 +10655,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bridge-grandpa"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -10363,8 +10674,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bridge-messages"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -10382,8 +10693,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bridge-parachains"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -10402,9 +10713,10 @@ dependencies = [
 
 [[package]]
 name = "pallet-bridge-relayers"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
+ "bp-header-chain",
  "bp-messages",
  "bp-relayers",
  "bp-runtime",
@@ -10412,7 +10724,10 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
+ "pallet-bridge-grandpa",
  "pallet-bridge-messages",
+ "pallet-bridge-parachains",
+ "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
@@ -10422,8 +10737,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-broker"
-version = "0.16.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.17.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10440,8 +10755,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-child-bounties"
-version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10458,8 +10773,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-collator-selection"
-version = "18.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "19.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10477,8 +10792,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-collective"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10493,8 +10808,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-collective-content"
-version = "0.15.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10507,8 +10822,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -10535,13 +10850,13 @@ dependencies = [
  "staging-xcm",
  "staging-xcm-builder",
  "wasm-instrument",
- "wasmi",
+ "wasmi 0.32.3",
 ]
 
 [[package]]
 name = "pallet-contracts-mock-network"
-version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "14.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10576,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10586,19 +10901,19 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "12.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
  "paste",
- "polkavm-derive",
+ "polkavm-derive 0.9.1",
  "scale-info",
 ]
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10613,8 +10928,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-core-fellowship"
-version = "21.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "22.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10631,21 +10946,23 @@ dependencies = [
 
 [[package]]
 name = "pallet-delegated-staking"
-version = "4.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "5.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "scale-info",
+ "sp-io",
  "sp-runtime",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-democracy"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10661,8 +10978,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-dev-mode"
-version = "19.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "20.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10686,8 +11003,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10708,8 +11025,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10739,8 +11056,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "38.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "39.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10757,8 +11074,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10775,8 +11092,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-glutton"
-version = "23.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "24.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -10803,8 +11120,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10825,8 +11142,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10841,8 +11158,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-im-online"
-version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10860,8 +11177,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-indices"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10876,8 +11193,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
-version = "25.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "26.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10902,8 +11219,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-lottery"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10929,8 +11246,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-membership"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10945,8 +11262,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-message-queue"
-version = "40.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "41.0.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10964,8 +11281,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-migrations"
-version = "7.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "8.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10981,8 +11298,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-mixnet"
-version = "0.13.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.14.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11000,8 +11317,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-mmr"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11017,8 +11334,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-multisig"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11043,8 +11360,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-fractionalization"
-version = "20.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "21.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11059,8 +11376,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nfts"
-version = "31.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "32.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -11076,8 +11393,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nfts-runtime-api"
-version = "23.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "24.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
@@ -11086,8 +11403,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nis"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11101,8 +11418,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-node-authorization"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11116,8 +11433,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "35.0.3"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11134,8 +11451,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11154,8 +11471,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "33.0.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -11164,8 +11481,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences"
-version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11180,8 +11497,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11203,8 +11520,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-paged-list"
-version = "0.15.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.16.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11220,8 +11537,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-parameters"
-version = "0.8.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11237,8 +11554,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-preimage"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11253,8 +11570,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-proxy"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11267,8 +11584,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "37.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11285,8 +11602,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-recovery"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11299,8 +11616,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-referenda"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -11317,8 +11634,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-remark"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11332,9 +11649,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-revive"
+version = "0.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "bitflags 1.3.2",
+ "environmental",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-balances",
+ "pallet-revive-fixtures",
+ "pallet-revive-proc-macro",
+ "pallet-revive-uapi",
+ "parity-scale-codec",
+ "paste",
+ "polkavm 0.10.0",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "staging-xcm",
+ "staging-xcm-builder",
+]
+
+[[package]]
+name = "pallet-revive-fixtures"
+version = "0.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "anyhow",
+ "frame-system",
+ "parity-wasm",
+ "polkavm-linker 0.10.0",
+ "sp-runtime",
+ "tempfile",
+ "toml 0.8.20",
+]
+
+[[package]]
+name = "pallet-revive-mock-network"
+version = "0.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-assets",
+ "pallet-balances",
+ "pallet-message-queue",
+ "pallet-proxy",
+ "pallet-revive",
+ "pallet-revive-proc-macro",
+ "pallet-revive-uapi",
+ "pallet-timestamp",
+ "pallet-utility",
+ "pallet-xcm",
+ "parity-scale-codec",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "polkadot-runtime-parachains",
+ "scale-info",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-tracing",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+ "xcm-simulator",
+]
+
+[[package]]
+name = "pallet-revive-proc-macro"
+version = "0.1.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "pallet-revive-uapi"
+version = "0.1.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "bitflags 1.3.2",
+ "parity-scale-codec",
+ "paste",
+ "polkavm-derive 0.10.0",
+ "scale-info",
+]
+
+[[package]]
 name = "pallet-root-offences"
-version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "35.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11348,8 +11765,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-root-testing"
-version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "14.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11362,8 +11779,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-safe-mode"
-version = "18.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "19.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11380,8 +11797,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-salary"
-version = "22.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "23.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11398,8 +11815,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-scheduler"
-version = "38.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "39.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11415,8 +11832,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-scored-pool"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11428,8 +11845,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11449,8 +11866,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11480,8 +11897,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-skip-feeless-payment"
-version = "12.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "13.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11492,8 +11909,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-society"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11509,8 +11926,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11532,7 +11949,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -11543,7 +11960,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -11551,8 +11968,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "24.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11561,8 +11978,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "40.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11577,8 +11994,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-statement"
-version = "19.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "20.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11594,8 +12011,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11636,8 +12053,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "36.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11655,8 +12072,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-tips"
-version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11673,8 +12090,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "37.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11688,10 +12105,10 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "41.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "sp-api",
@@ -11704,8 +12121,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -11716,8 +12133,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-storage"
-version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "frame-benchmarking",
@@ -11736,8 +12153,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-treasury"
-version = "36.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11754,8 +12171,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-tx-pause"
-version = "18.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "19.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11771,8 +12188,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-uniques"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11785,8 +12202,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-utility"
-version = "37.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11810,8 +12227,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-vesting"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11824,8 +12241,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-whitelist"
-version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11838,8 +12255,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "16.0.2"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "17.0.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -11862,8 +12279,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11880,13 +12297,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub"
-version = "0.12.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.13.3"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bp-messages",
  "bp-runtime",
  "bp-xcm-bridge-hub",
- "bridge-runtime-common",
  "frame-support",
  "frame-system",
  "log",
@@ -11903,8 +12319,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
-version = "0.14.2"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.15.3"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -11933,8 +12349,8 @@ dependencies = [
 
 [[package]]
 name = "parachains-common"
-version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -11963,8 +12379,8 @@ dependencies = [
 
 [[package]]
 name = "parachains-runtimes-test-utils"
-version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "19.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -12474,6 +12890,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-approval-distribution"
+version = "18.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "bitvec",
+ "futures",
+ "futures-timer",
+ "itertools 0.11.0",
+ "polkadot-node-jaeger",
+ "polkadot-node-metrics",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "rand 0.8.5",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-availability-bitfield-distribution"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "always-assert",
+ "futures",
+ "futures-timer",
+ "polkadot-node-network-protocol",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "rand 0.8.5",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-availability-distribution"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "derive_more 0.99.19",
+ "fatality",
+ "futures",
+ "parity-scale-codec",
+ "polkadot-erasure-coding",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "rand 0.8.5",
+ "sc-network",
+ "schnellru",
+ "sp-core",
+ "sp-keystore",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-availability-recovery"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "async-trait",
+ "fatality",
+ "futures",
+ "parity-scale-codec",
+ "polkadot-erasure-coding",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "rand 0.8.5",
+ "sc-network",
+ "schnellru",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing-gum",
+]
+
+[[package]]
 name = "polkadot-ckb-merkle-mountain-range"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12485,20 +12984,23 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "18.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "19.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cfg-if",
+ "clap",
  "frame-benchmarking-cli",
  "futures",
  "log",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-service",
+ "sc-cli",
  "sc-executor",
  "sc-service",
  "sc-storage-monitor",
  "sc-sysinfo",
+ "sc-tracing",
  "sp-core",
  "sp-io",
  "sp-keyring",
@@ -12509,9 +13011,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-collator-protocol"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "bitvec",
+ "fatality",
+ "futures",
+ "futures-timer",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "schnellru",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
+ "thiserror 1.0.69",
+ "tokio-util",
+ "tracing-gum",
+]
+
+[[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12520,9 +13045,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-dispute-distribution"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "derive_more 0.99.19",
+ "fatality",
+ "futures",
+ "futures-timer",
+ "indexmap 2.8.0",
+ "parity-scale-codec",
+ "polkadot-erasure-coding",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "sc-network",
+ "schnellru",
+ "sp-application-crypto",
+ "sp-keystore",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
 name = "polkadot-erasure-coding"
-version = "15.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -12534,9 +13084,234 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-gossip-support"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "polkadot-node-network-protocol",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "sc-network",
+ "sc-network-common",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
+ "sp-keystore",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-network-bridge"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "always-assert",
+ "async-trait",
+ "bytes",
+ "fatality",
+ "futures",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "polkadot-node-metrics",
+ "polkadot-node-network-protocol",
+ "polkadot-node-subsystem",
+ "polkadot-overseer",
+ "polkadot-primitives",
+ "sc-network",
+ "sp-consensus",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-collation-generation"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "futures",
+ "parity-scale-codec",
+ "polkadot-erasure-coding",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "sp-core",
+ "sp-maybe-compressed-blob",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-approval-voting"
+version = "18.3.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "bitvec",
+ "derive_more 0.99.19",
+ "futures",
+ "futures-timer",
+ "itertools 0.11.0",
+ "kvdb",
+ "merlin",
+ "parity-scale-codec",
+ "polkadot-node-jaeger",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-overseer",
+ "polkadot-primitives",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "sc-keystore",
+ "schnellru",
+ "schnorrkel 0.11.4",
+ "sp-application-crypto",
+ "sp-consensus",
+ "sp-consensus-slots",
+ "sp-runtime",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-av-store"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "bitvec",
+ "futures",
+ "futures-timer",
+ "kvdb",
+ "parity-scale-codec",
+ "polkadot-erasure-coding",
+ "polkadot-node-jaeger",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-overseer",
+ "polkadot-primitives",
+ "sp-consensus",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-backing"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "bitvec",
+ "fatality",
+ "futures",
+ "polkadot-erasure-coding",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "polkadot-statement-table",
+ "schnellru",
+ "sp-keystore",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-bitfield-signing"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "futures",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "sp-keystore",
+ "thiserror 1.0.69",
+ "tracing-gum",
+ "wasm-timer",
+]
+
+[[package]]
+name = "polkadot-node-core-candidate-validation"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "parity-scale-codec",
+ "polkadot-node-core-pvf",
+ "polkadot-node-metrics",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-overseer",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "sp-application-crypto",
+ "sp-keystore",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-chain-api"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "futures",
+ "polkadot-node-metrics",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-types",
+ "sc-client-api",
+ "sc-consensus-babe",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-chain-selection"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "kvdb",
+ "parity-scale-codec",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-dispute-coordinator"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "fatality",
+ "futures",
+ "kvdb",
+ "parity-scale-codec",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "sc-keystore",
+ "schnellru",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "futures",
@@ -12551,9 +13326,127 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-node-core-prospective-parachains"
+version = "17.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "fatality",
+ "futures",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-provisioner"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "bitvec",
+ "fatality",
+ "futures",
+ "futures-timer",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "schnellru",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-pvf"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "always-assert",
+ "array-bytes",
+ "blake3",
+ "cfg-if",
+ "futures",
+ "futures-timer",
+ "parity-scale-codec",
+ "pin-project",
+ "polkadot-core-primitives",
+ "polkadot-node-core-pvf-common",
+ "polkadot-node-metrics",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "rand 0.8.5",
+ "slotmap",
+ "sp-core",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-pvf-checker"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "futures",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-overseer",
+ "polkadot-primitives",
+ "sp-keystore",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-pvf-common"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "cpu-time",
+ "futures",
+ "landlock",
+ "libc",
+ "nix 0.28.0",
+ "parity-scale-codec",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "sc-executor",
+ "sc-executor-common",
+ "sc-executor-wasmtime",
+ "seccompiler",
+ "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
+ "sp-externalities",
+ "sp-io",
+ "sp-tracing",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
+name = "polkadot-node-core-runtime-api"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "futures",
+ "polkadot-node-metrics",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-types",
+ "polkadot-primitives",
+ "schnellru",
+ "sp-consensus-babe",
+ "tracing-gum",
+]
+
+[[package]]
 name = "polkadot-node-jaeger"
-version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "lazy_static",
  "log",
@@ -12571,8 +13464,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -12590,8 +13483,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "17.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "18.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -12616,19 +13509,22 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "15.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bitvec",
  "bounded-vec",
  "futures",
+ "futures-timer",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "schnorrkel",
+ "sc-keystore",
+ "schnorrkel 0.11.4",
  "serde",
  "sp-application-crypto",
  "sp-consensus-babe",
+ "sp-consensus-slots",
  "sp-core",
  "sp-keystore",
  "sp-maybe-compressed-blob",
@@ -12639,8 +13535,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -12649,8 +13545,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "17.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -12679,8 +13575,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "17.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "derive_more 0.99.19",
@@ -12715,8 +13611,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "futures",
@@ -12736,9 +13632,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-parachain-lib"
+version = "0.3.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "async-trait",
+ "clap",
+ "color-print",
+ "cumulus-client-cli",
+ "cumulus-client-collator",
+ "cumulus-client-consensus-aura",
+ "cumulus-client-consensus-common",
+ "cumulus-client-consensus-proposer",
+ "cumulus-client-consensus-relay-chain",
+ "cumulus-client-parachain-inherent",
+ "cumulus-client-service",
+ "cumulus-primitives-aura",
+ "cumulus-primitives-core",
+ "cumulus-relay-chain-interface",
+ "docify",
+ "frame-benchmarking",
+ "frame-benchmarking-cli",
+ "frame-support",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
+ "futures",
+ "jsonrpsee",
+ "log",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "parachains-common",
+ "parity-scale-codec",
+ "polkadot-cli",
+ "polkadot-primitives",
+ "sc-basic-authorship",
+ "sc-chain-spec",
+ "sc-cli",
+ "sc-client-api",
+ "sc-client-db",
+ "sc-consensus",
+ "sc-executor",
+ "sc-network",
+ "sc-rpc",
+ "sc-service",
+ "sc-sysinfo",
+ "sc-telemetry",
+ "sc-tracing",
+ "sc-transaction-pool",
+ "serde",
+ "serde_json",
+ "sp-api",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-session",
+ "sp-timestamp",
+ "sp-transaction-pool",
+ "sp-version",
+ "sp-weights",
+ "substrate-frame-rpc-system",
+ "substrate-prometheus-endpoint",
+ "substrate-state-trie-migration-rpc",
+]
+
+[[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.19",
@@ -12753,8 +13718,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "15.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bitvec",
  "hex-literal 0.4.1",
@@ -12779,10 +13744,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-rpc"
-version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "19.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "mmr-rpc",
  "pallet-transaction-payment-rpc",
  "polkadot-primitives",
@@ -12814,8 +13779,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "16.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -12864,8 +13829,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -12876,8 +13841,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "16.0.3"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "17.0.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -12893,6 +13858,7 @@ dependencies = [
  "pallet-balances",
  "pallet-broker",
  "pallet-message-queue",
+ "pallet-mmr",
  "pallet-session",
  "pallet-staking",
  "pallet-timestamp",
@@ -12916,6 +13882,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-executor",
  "static_assertions",
@@ -12923,31 +13890,20 @@ dependencies = [
 
 [[package]]
 name = "polkadot-sdk"
-version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.9.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "asset-test-utils",
  "assets-common",
  "binary-merkle-tree",
- "bp-asset-hub-rococo",
- "bp-asset-hub-westend",
- "bp-bridge-hub-cumulus",
- "bp-bridge-hub-kusama",
- "bp-bridge-hub-polkadot",
- "bp-bridge-hub-rococo",
- "bp-bridge-hub-westend",
  "bp-header-chain",
- "bp-kusama",
  "bp-messages",
  "bp-parachains",
  "bp-polkadot",
- "bp-polkadot-bulletin",
  "bp-polkadot-core",
  "bp-relayers",
- "bp-rococo",
  "bp-runtime",
  "bp-test-utils",
- "bp-westend",
  "bp-xcm-bridge-hub",
  "bp-xcm-bridge-hub-router",
  "bridge-hub-common",
@@ -13052,6 +14008,9 @@ dependencies = [
  "pallet-recovery",
  "pallet-referenda",
  "pallet-remark",
+ "pallet-revive",
+ "pallet-revive-fixtures",
+ "pallet-revive-mock-network",
  "pallet-root-offences",
  "pallet-root-testing",
  "pallet-safe-mode",
@@ -13090,6 +14049,7 @@ dependencies = [
  "polkadot-cli",
  "polkadot-core-primitives",
  "polkadot-node-metrics",
+ "polkadot-parachain-lib",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-common",
@@ -13097,7 +14057,6 @@ dependencies = [
  "polkadot-runtime-parachains",
  "polkadot-sdk-frame",
  "polkadot-service",
- "rococo-runtime-constants",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-chain-spec",
@@ -13115,8 +14074,6 @@ dependencies = [
  "sc-network-sync",
  "sc-offchain",
  "sc-rpc",
- "sc-rpc-api",
- "sc-rpc-spec-v2",
  "sc-service",
  "sc-storage-monitor",
  "sc-sync-state-rpc",
@@ -13157,7 +14114,7 @@ dependencies = [
  "sp-core",
  "sp-core-hashing",
  "sp-crypto-ec-utils",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-genesis-builder",
@@ -13196,14 +14153,13 @@ dependencies = [
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
  "testnet-parachains-constants",
- "westend-runtime-constants",
  "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "polkadot-sdk-frame"
-version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.7.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -13234,46 +14190,64 @@ dependencies = [
 
 [[package]]
 name = "polkadot-service"
-version = "18.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "19.0.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
  "frame-benchmarking-cli",
- "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
  "futures",
- "hex-literal 0.4.1",
  "is_executable",
  "kvdb",
+ "kvdb-rocksdb",
  "log",
  "mmr-gadget",
- "pallet-babe",
- "pallet-staking",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
+ "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.3",
+ "polkadot-approval-distribution",
+ "polkadot-availability-bitfield-distribution",
+ "polkadot-availability-distribution",
+ "polkadot-availability-recovery",
+ "polkadot-collator-protocol",
  "polkadot-core-primitives",
+ "polkadot-dispute-distribution",
+ "polkadot-gossip-support",
+ "polkadot-network-bridge",
+ "polkadot-node-collation-generation",
+ "polkadot-node-core-approval-voting",
+ "polkadot-node-core-av-store",
+ "polkadot-node-core-backing",
+ "polkadot-node-core-bitfield-signing",
+ "polkadot-node-core-candidate-validation",
+ "polkadot-node-core-chain-api",
+ "polkadot-node-core-chain-selection",
+ "polkadot-node-core-dispute-coordinator",
  "polkadot-node-core-parachains-inherent",
+ "polkadot-node-core-prospective-parachains",
+ "polkadot-node-core-provisioner",
+ "polkadot-node-core-pvf",
+ "polkadot-node-core-pvf-checker",
+ "polkadot-node-core-runtime-api",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-rpc",
  "polkadot-runtime-parachains",
+ "polkadot-statement-distribution",
  "rococo-runtime",
  "sc-authority-discovery",
  "sc-basic-authorship",
- "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
- "sc-client-db",
  "sc-consensus",
  "sc-consensus-babe",
  "sc-consensus-beefy",
@@ -13282,7 +14256,6 @@ dependencies = [
  "sc-executor",
  "sc-keystore",
  "sc-network",
- "sc-network-common",
  "sc-network-sync",
  "sc-offchain",
  "sc-service",
@@ -13291,7 +14264,6 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
- "schnellru",
  "serde",
  "serde_json",
  "sp-api",
@@ -13303,16 +14275,14 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
  "sp-core",
+ "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
  "sp-keyring",
- "sp-keystore",
  "sp-mmr-primitives",
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-state-machine",
- "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-version",
@@ -13326,9 +14296,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-statement-distribution"
+version = "18.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "arrayvec 0.7.6",
+ "bitvec",
+ "fatality",
+ "futures",
+ "futures-timer",
+ "indexmap 2.8.0",
+ "parity-scale-codec",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-util",
+ "polkadot-primitives",
+ "sp-keystore",
+ "sp-staking",
+ "thiserror 1.0.69",
+ "tracing-gum",
+]
+
+[[package]]
 name = "polkadot-statement-table"
-version = "15.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13344,9 +14337,22 @@ checksum = "8a3693e5efdb2bf74e449cd25fd777a28bd7ed87e41f5d5da75eb31b4de48b94"
 dependencies = [
  "libc",
  "log",
- "polkavm-assembler",
- "polkavm-common",
- "polkavm-linux-raw",
+ "polkavm-assembler 0.9.0",
+ "polkavm-common 0.9.0",
+ "polkavm-linux-raw 0.9.0",
+]
+
+[[package]]
+name = "polkavm"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ec0c5935f2eff23cfc4653002f4f8d12b37f87a720e0631282d188c32089d6"
+dependencies = [
+ "libc",
+ "log",
+ "polkavm-assembler 0.10.0",
+ "polkavm-common 0.10.0",
+ "polkavm-linux-raw 0.10.0",
 ]
 
 [[package]]
@@ -13354,6 +14360,15 @@ name = "polkavm-assembler"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa96d6d868243acc12de813dd48e756cbadcc8e13964c70d272753266deadc1"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "polkavm-assembler"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e4fd5a43100bf1afe9727b8130d01f966f5cfc9144d5604b21e795c2bcd80e"
 dependencies = [
  "log",
 ]
@@ -13368,12 +14383,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkavm-common"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0097b48bc0bedf9f3f537ce8f37e8f1202d8d83f9b621bdb21ff2c59b9097c50"
+dependencies = [
+ "log",
+ "polkavm-assembler 0.10.0",
+]
+
+[[package]]
 name = "polkavm-derive"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae8c4bea6f3e11cd89bb18bcdddac10bd9a24015399bd1c485ad68a985a19606"
 dependencies = [
- "polkavm-derive-impl-macro",
+ "polkavm-derive-impl-macro 0.9.0",
+]
+
+[[package]]
+name = "polkavm-derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dcc701385c08c31bdb0569f0c51a290c580d892fa77f1dd88a7352a62679ecf"
+dependencies = [
+ "polkavm-derive-impl-macro 0.10.0",
 ]
 
 [[package]]
@@ -13382,7 +14416,19 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c4fdfc49717fb9a196e74a5d28e0bc764eb394a2c803eb11133a31ac996c60c"
 dependencies = [
- "polkavm-common",
+ "polkavm-common 0.9.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "polkavm-derive-impl"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7855353a5a783dd5d09e3b915474bddf66575f5a3cf45dec8d1c5e051ba320dc"
+dependencies = [
+ "polkavm-common 0.10.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -13394,7 +14440,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
- "polkavm-derive-impl",
+ "polkavm-derive-impl 0.9.0",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "polkavm-derive-impl-macro"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9324fe036de37c17829af233b46ef6b5562d4a0c09bb7fdb9f8378856dee30cf"
+dependencies = [
+ "polkavm-derive-impl 0.10.0",
  "syn 2.0.100",
 ]
 
@@ -13408,7 +14464,22 @@ dependencies = [
  "hashbrown 0.14.5",
  "log",
  "object 0.32.2",
- "polkavm-common",
+ "polkavm-common 0.9.0",
+ "regalloc2 0.9.3",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "polkavm-linker"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d704edfe7bdcc876784f19436d53d515b65eb07bc9a0fae77085d552c2dbbb5"
+dependencies = [
+ "gimli 0.28.1",
+ "hashbrown 0.14.5",
+ "log",
+ "object 0.36.7",
+ "polkavm-common 0.10.0",
  "regalloc2 0.9.3",
  "rustc-demangle",
 ]
@@ -13418,6 +14489,12 @@ name = "polkavm-linux-raw"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26e85d3456948e650dff0cfc85603915847faf893ed1e66b020bb82ef4557120"
+
+[[package]]
+name = "polkavm-linux-raw"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26e45fa59c7e1bb12ef5289080601e9ec9b31435f6e32800a5c90c132453d126"
 
 [[package]]
 name = "polling"
@@ -14757,8 +15834,8 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "18.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -14857,8 +15934,8 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -15267,6 +16344,17 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3ffab8f9715a0d455df4bbb9d21e91135aab3cd3ca187af0cd0c3c3f868fdc"
+dependencies = [
+ "byteorder",
+ "thiserror-core",
+ "twox-hash",
+]
+
+[[package]]
+name = "ruzstd"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
@@ -15351,7 +16439,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "log",
  "sp-core",
@@ -15361,8 +16449,8 @@ dependencies = [
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.44.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.45.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "futures",
@@ -15391,8 +16479,8 @@ dependencies = [
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.44.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.45.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "futures",
  "futures-timer",
@@ -15414,7 +16502,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -15428,8 +16516,8 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "docify",
@@ -15445,7 +16533,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -15456,7 +16544,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -15466,8 +16554,8 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.46.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.47.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -15508,7 +16596,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "fnv",
  "futures",
@@ -15534,8 +16622,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.44.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.44.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -15560,8 +16648,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.43.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "futures",
@@ -15583,9 +16671,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-consensus-aura"
+version = "0.45.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
+dependencies = [
+ "async-trait",
+ "futures",
+ "log",
+ "parity-scale-codec",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-consensus-slots",
+ "sc-telemetry",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-aura",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
+ "substrate-prometheus-endpoint",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "sc-consensus-babe"
-version = "0.44.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.45.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -15610,7 +16727,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -15620,11 +16737,11 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.44.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.45.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "futures",
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "sc-consensus-babe",
  "sc-consensus-epochs",
  "sc-rpc-api",
@@ -15642,8 +16759,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "23.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "24.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -15667,7 +16784,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-beefy",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -15678,11 +16795,11 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "23.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "24.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "futures",
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -15698,8 +16815,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.43.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -15711,8 +16828,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.29.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.30.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "ahash 0.8.11",
  "array-bytes",
@@ -15746,7 +16863,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -15755,12 +16872,12 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.29.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.30.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "finality-grandpa",
  "futures",
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -15775,8 +16892,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.43.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "futures",
@@ -15798,8 +16915,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.40.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.40.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -15822,9 +16939,9 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
- "polkavm",
+ "polkavm 0.9.3",
  "sc-allocator",
  "sp-maybe-compressed-blob",
  "sp-wasm-interface",
@@ -15835,10 +16952,10 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "log",
- "polkavm",
+ "polkavm 0.9.3",
  "sc-executor-common",
  "sp-wasm-interface",
 ]
@@ -15846,7 +16963,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -15863,10 +16980,10 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.43.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
- "ansi_term",
+ "console",
  "futures",
  "futures-timer",
  "log",
@@ -15881,7 +16998,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -15894,8 +17011,8 @@ dependencies = [
 
 [[package]]
 name = "sc-mixnet"
-version = "0.14.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.15.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -15923,8 +17040,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.44.2"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.45.6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -15974,8 +17091,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.43.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -15992,8 +17109,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.44.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.45.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "ahash 0.8.11",
  "futures",
@@ -16011,8 +17128,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-light"
-version = "0.43.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.44.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -16032,8 +17149,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-sync"
-version = "0.43.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.44.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -16069,8 +17186,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.43.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.44.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "futures",
@@ -16089,7 +17206,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -16105,8 +17222,8 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "40.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -16140,7 +17257,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -16148,11 +17265,11 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "40.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "futures",
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -16180,10 +17297,10 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.43.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.44.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "parity-scale-codec",
  "sc-chain-spec",
  "sc-mixnet",
@@ -16200,9 +17317,10 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "16.0.2"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "17.1.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
+ "dyn-clone",
  "forwarded-header-value",
  "futures",
  "governor",
@@ -16210,8 +17328,9 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "ip_network",
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "log",
+ "sc-rpc-api",
  "serde",
  "serde_json",
  "substrate-prometheus-endpoint",
@@ -16222,14 +17341,14 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.44.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.45.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "futures",
  "futures-util",
  "hex",
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -16254,15 +17373,15 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.45.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.46.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "directories",
  "exit-future",
  "futures",
  "futures-timer",
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -16319,7 +17438,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16330,7 +17449,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.22.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "clap",
  "fs4",
@@ -16342,10 +17461,10 @@ dependencies = [
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.44.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.45.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "parity-scale-codec",
  "sc-chain-spec",
  "sc-client-api",
@@ -16361,8 +17480,8 @@ dependencies = [
 
 [[package]]
 name = "sc-sysinfo"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "derive_more 0.99.19",
  "futures",
@@ -16375,15 +17494,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "sp-io",
  "sp-std",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "24.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "25.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "chrono",
  "futures",
@@ -16402,18 +17521,17 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "37.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
- "ansi_term",
  "chrono",
+ "console",
  "is-terminal",
  "lazy_static",
  "libc",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "regex",
  "rustc-hash 1.1.0",
  "sc-client-api",
  "sc-tracing-proc-macro",
@@ -16433,7 +17551,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -16444,7 +17562,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "futures",
@@ -16460,7 +17578,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -16471,7 +17589,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "futures",
@@ -16487,7 +17605,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -16694,6 +17812,22 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "844b7645371e6ecdf61ff246ba1958c29e802881a749ae3fb1993675d210d28d"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.6",
+ "curve25519-dalek-ng",
+ "merlin",
+ "rand_core 0.6.4",
+ "sha2 0.9.9",
+ "subtle-ng",
+ "zeroize",
+]
+
+[[package]]
+name = "schnorrkel"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de18f6d8ba0aad7045f5feae07ec29899c1112584a38509a84ad7b04451eaa0"
@@ -16779,6 +17913,15 @@ dependencies = [
  "serdect",
  "subtle 2.6.1",
  "zeroize",
+]
+
+[[package]]
+name = "seccompiler"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345a3e4dddf721a478089d4697b83c6c0a8f5bf16086f6c13397e4534eb6e2e5"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -17118,6 +18261,19 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.1",
+]
+
+[[package]]
+name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
@@ -17399,12 +18555,21 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
  "sp-runtime",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -17418,19 +18583,90 @@ dependencies = [
 
 [[package]]
 name = "smol"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f2b548cd8447f8de0fdf1c592929f70f4fc7039a05e47404b0d096ec6987a1"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-executor",
+ "async-fs 1.6.0",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-net 1.8.0",
+ "async-process 1.8.1",
+ "blocking",
+ "futures-lite 1.13.0",
+]
+
+[[package]]
+name = "smol"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
- "async-fs",
+ "async-fs 2.1.2",
  "async-io 2.4.0",
  "async-lock 3.4.0",
- "async-net",
- "async-process",
+ "async-net 2.0.0",
+ "async-process 2.3.0",
  "blocking",
  "futures-lite 2.6.0",
+]
+
+[[package]]
+name = "smoldot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bb30cf57b7b5f6109ce17c3164445e2d6f270af2cb48f6e4d31c2967c9a9f5"
+dependencies = [
+ "arrayvec 0.7.6",
+ "async-lock 2.8.0",
+ "atomic-take",
+ "base64 0.21.7",
+ "bip39",
+ "blake2-rfc",
+ "bs58 0.5.1",
+ "chacha20",
+ "crossbeam-queue",
+ "derive_more 0.99.19",
+ "ed25519-zebra",
+ "either",
+ "event-listener 2.5.3",
+ "fnv",
+ "futures-lite 1.13.0",
+ "futures-util",
+ "hashbrown 0.14.5",
+ "hex",
+ "hmac 0.12.1",
+ "itertools 0.11.0",
+ "libsecp256k1",
+ "merlin",
+ "no-std-net",
+ "nom",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "pbkdf2",
+ "pin-project",
+ "poly1305",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "ruzstd 0.4.0",
+ "schnorrkel 0.10.2",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "sha3",
+ "siphasher 0.3.11",
+ "slab",
+ "smallvec",
+ "soketto 0.7.1",
+ "twox-hash",
+ "wasmi 0.31.2",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -17471,8 +18707,8 @@ dependencies = [
  "poly1305",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "ruzstd",
- "schnorrkel",
+ "ruzstd 0.6.0",
+ "schnorrkel 0.11.4",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -17480,10 +18716,46 @@ dependencies = [
  "siphasher 1.0.1",
  "slab",
  "smallvec",
- "soketto",
+ "soketto 0.8.1",
  "twox-hash",
- "wasmi",
+ "wasmi 0.32.3",
  "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "smoldot-light"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256b5bad1d6b49045e95fe87492ce73d5af81545d8b4d8318a872d2007024c33"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-lock 2.8.0",
+ "base64 0.21.7",
+ "blake2-rfc",
+ "derive_more 0.99.19",
+ "either",
+ "event-listener 2.5.3",
+ "fnv",
+ "futures-channel",
+ "futures-lite 1.13.0",
+ "futures-util",
+ "hashbrown 0.14.5",
+ "hex",
+ "itertools 0.11.0",
+ "log",
+ "lru 0.11.1",
+ "no-std-net",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_json",
+ "siphasher 0.3.11",
+ "slab",
+ "smol 1.3.0",
+ "smoldot 0.11.0",
  "zeroize",
 ]
 
@@ -17518,8 +18790,8 @@ dependencies = [
  "serde_json",
  "siphasher 1.0.1",
  "slab",
- "smol",
- "smoldot",
+ "smol 2.0.2",
+ "smoldot 0.18.0",
  "zeroize",
 ]
 
@@ -17558,8 +18830,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-beacon-primitives"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.10.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -17580,8 +18852,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-core"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.10.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -17604,7 +18876,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-ethereum"
 version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "ethabi-decode",
  "ethbloom 0.13.0",
@@ -17638,8 +18910,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-merkle-tree"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.9.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17649,8 +18921,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.10.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -17662,8 +18934,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-ethereum-client"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.10.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -17687,8 +18959,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-ethereum-client-fixtures"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "hex-literal 0.4.1",
  "snowbridge-beacon-primitives",
@@ -17699,8 +18971,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-inbound-queue"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.10.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "alloy-primitives 0.4.2",
  "alloy-sol-types 0.4.2",
@@ -17727,8 +18999,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-inbound-queue-fixtures"
-version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.18.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "hex-literal 0.4.1",
  "snowbridge-beacon-primitives",
@@ -17739,8 +19011,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-outbound-queue"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.10.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -17761,8 +19033,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-system"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.10.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -17781,8 +19053,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-router-primitives"
-version = "0.15.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.16.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "hex-literal 0.4.1",
@@ -17800,8 +19072,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-runtime-common"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.10.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "log",
@@ -17816,8 +19088,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-runtime-test-common"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.12.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -17847,8 +19119,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-system-runtime-api"
-version = "0.9.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.10.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
@@ -17879,6 +19151,21 @@ dependencies = [
 
 [[package]]
 name = "soketto"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "futures",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha-1 0.9.8",
+]
+
+[[package]]
+name = "soketto"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
@@ -17896,7 +19183,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "hash-db",
@@ -17918,7 +19205,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -17932,7 +19219,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17944,7 +19231,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -17958,7 +19245,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17970,7 +19257,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -17980,7 +19267,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -17999,7 +19286,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "futures",
@@ -18014,7 +19301,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18030,7 +19317,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18047,8 +19334,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "22.1.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -18057,18 +19344,19 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
  "sp-runtime",
+ "sp-weights",
  "strum 0.26.3",
 ]
 
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -18085,7 +19373,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-pow"
 version = "0.40.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -18095,8 +19383,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.40.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.40.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18107,7 +19395,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -18132,11 +19420,11 @@ dependencies = [
  "primitive-types 0.12.2",
  "rand 0.8.5",
  "scale-info",
- "schnorrkel",
+ "schnorrkel 0.11.4",
  "secp256k1 0.28.2",
  "secrecy 0.8.0",
  "serde",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -18153,15 +19441,15 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
 ]
 
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.14.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -18195,7 +19483,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -18208,17 +19496,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -18227,7 +19515,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -18237,7 +19525,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -18246,8 +19534,8 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.15.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.15.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18259,7 +19547,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -18272,7 +19560,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bytes",
  "docify",
@@ -18280,11 +19568,11 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.9.1",
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -18298,7 +19586,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -18308,7 +19596,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -18319,7 +19607,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -18328,7 +19616,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -18338,7 +19626,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18348,8 +19636,8 @@ dependencies = [
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "34.1.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -18366,7 +19654,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18379,7 +19667,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -18389,7 +19677,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -18399,7 +19687,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -18408,8 +19696,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "39.0.3"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "39.0.5"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "either",
@@ -18435,12 +19723,12 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive",
+ "polkavm-derive 0.9.1",
  "primitive-types 0.12.2",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
@@ -18454,7 +19742,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "Inflector",
  "expander",
@@ -18466,8 +19754,8 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "35.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18480,8 +19768,8 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "36.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -18494,7 +19782,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "hash-db",
  "log",
@@ -18514,7 +19802,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "aes-gcm 0.10.3",
  "curve25519-dalek",
@@ -18527,7 +19815,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -18538,12 +19826,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "impl-serde 0.4.0",
  "parity-scale-codec",
@@ -18555,7 +19843,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18566,8 +19854,8 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "17.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -18578,7 +19866,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -18587,7 +19875,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18601,7 +19889,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "ahash 0.8.11",
  "hash-db",
@@ -18624,7 +19912,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "impl-serde 0.4.0",
  "parity-scale-codec",
@@ -18641,7 +19929,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -18651,8 +19939,8 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "21.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "21.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -18664,7 +19952,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -18754,8 +20042,8 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-node-inspect"
-version = "0.22.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.23.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -18772,8 +20060,8 @@ dependencies = [
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.16.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.17.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -18785,8 +20073,8 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "14.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "14.2.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -18797,19 +20085,21 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
+ "sp-runtime",
  "sp-weights",
  "xcm-procedural",
 ]
 
 [[package]]
 name = "staging-xcm-builder"
-version = "16.0.4"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "17.0.4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "log",
+ "pallet-asset-conversion",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
@@ -18824,8 +20114,8 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "17.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -18949,7 +20239,7 @@ dependencies = [
  "openssl-sys",
  "sctp-proto",
  "serde",
- "sha-1",
+ "sha-1 0.10.1",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -19113,11 +20403,11 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
- "schnorrkel",
+ "schnorrkel 0.11.4",
  "sha2 0.10.8",
  "zeroize",
 ]
@@ -19125,17 +20415,17 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "38.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "39.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
  "futures",
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "sc-rpc-api",
@@ -19150,7 +20440,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -19163,10 +20453,10 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "38.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "parity-scale-codec",
  "sc-client-api",
  "sc-rpc-api",
@@ -19180,8 +20470,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "24.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "24.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -19189,10 +20479,11 @@ dependencies = [
  "console",
  "filetime",
  "frame-metadata 16.0.0",
+ "jobserver",
  "merkleized-metadata",
  "parity-scale-codec",
  "parity-wasm",
- "polkavm-linker",
+ "polkavm-linker 0.9.2",
  "sc-executor",
  "sp-core",
  "sp-io",
@@ -19219,6 +20510,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
 name = "subxt"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19232,7 +20529,7 @@ dependencies = [
  "futures",
  "hex",
  "impl-serde 0.5.0",
- "jsonrpsee 0.24.9",
+ "jsonrpsee",
  "parity-scale-codec",
  "primitive-types 0.13.1",
  "scale-bits 0.7.0",
@@ -19313,7 +20610,7 @@ dependencies = [
  "futures-util",
  "serde",
  "serde_json",
- "smoldot-light",
+ "smoldot-light 0.16.2",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -19366,7 +20663,7 @@ dependencies = [
  "parity-scale-codec",
  "pbkdf2",
  "regex",
- "schnorrkel",
+ "schnorrkel 0.11.4",
  "scrypt",
  "secp256k1 0.30.0",
  "secrecy 0.10.3",
@@ -19759,8 +21056,8 @@ dependencies = [
 
 [[package]]
 name = "testnet-parachains-constants"
-version = "9.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "10.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -19788,6 +21085,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-core"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c001ee18b7e5e3f62cbf58c7fe220119e68d902bb7443179c0c8aef30090e999"
+dependencies = [
+ "thiserror-core-impl",
+]
+
+[[package]]
+name = "thiserror-core-impl"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -20004,7 +21321,7 @@ dependencies = [
  "eth-bridge",
  "futures",
  "hex-literal 1.0.0",
- "jsonrpsee 0.23.2",
+ "jsonrpsee",
  "libsecp256k1",
  "log",
  "pallet-members",
@@ -20028,7 +21345,6 @@ dependencies = [
  "env_logger 0.11.7",
  "eth-bridge",
  "eth-bridge-runtime-api",
- "hex-literal 1.0.0",
  "log",
  "pallet-airdrop",
  "pallet-dmail",
@@ -20456,8 +21772,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "15.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "16.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -20468,7 +21784,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "expander",
  "proc-macro-crate 3.3.0",
@@ -20540,6 +21856,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time 0.3.41",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -21270,6 +22587,19 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8281d1d660cdf54c76a3efa9ddd0c270cada1383a995db3ccb43d166456c7"
+dependencies = [
+ "smallvec",
+ "spin 0.9.8",
+ "wasmi_arena",
+ "wasmi_core 0.13.0",
+ "wasmparser-nostd",
+]
+
+[[package]]
+name = "wasmi"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50386c99b9c32bd2ed71a55b6dd4040af2580530fae8bdb9a6576571a80d0cca"
@@ -21281,9 +22611,15 @@ dependencies = [
  "smallvec",
  "spin 0.9.8",
  "wasmi_collections",
- "wasmi_core",
+ "wasmi_core 0.32.3",
  "wasmparser-nostd",
 ]
+
+[[package]]
+name = "wasmi_arena"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
 
 [[package]]
 name = "wasmi_collections"
@@ -21294,6 +22630,18 @@ dependencies = [
  "ahash 0.8.11",
  "hashbrown 0.14.5",
  "string-interner",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "num-traits",
+ "paste",
 ]
 
 [[package]]
@@ -21592,8 +22940,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "19.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "18.0.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -21636,6 +22984,7 @@ dependencies = [
  "pallet-nomination-pools-runtime-api",
  "pallet-offences",
  "pallet-offences-benchmarking",
+ "pallet-parameters",
  "pallet-preimage",
  "pallet-proxy",
  "pallet-recovery",
@@ -21646,7 +22995,6 @@ dependencies = [
  "pallet-session-benchmarking",
  "pallet-society",
  "pallet-staking",
- "pallet-staking-reward-curve",
  "pallet-staking-runtime-api",
  "pallet-state-trie-migration",
  "pallet-sudo",
@@ -21667,6 +23015,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_derive",
+ "serde_json",
  "smallvec",
  "sp-api",
  "sp-application-crypto",
@@ -21675,6 +23024,7 @@ dependencies = [
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
+ "sp-consensus-grandpa",
  "sp-core",
  "sp-genesis-builder",
  "sp-inherents",
@@ -21698,8 +23048,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -22407,7 +23757,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -22417,8 +23767,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.3.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "0.4.3"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -22431,8 +23781,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-simulator"
-version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.15.8-anlog0#ce46b551d7c619615cac0c4cf96b23f8ed87bbc6"
+version = "17.0.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.16.6-anlog0#3ea2353be04c0232549e2e580a94ed1c9e78ec05"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,10 +71,10 @@ scale-decode = { version = "0.16.0", default-features = false, features = [ "der
 scale-info = { version = "2.11.6", default-features = false, features = [ "derive" ] }
 
 # main substrate sdk
-polkadot-sdk = { git = "https://github.com/Analog-Labs/polkadot-sdk", tag = "v1.15.8-anlog0", default-features = false }
+polkadot-sdk = { git = "https://github.com/Analog-Labs/polkadot-sdk", tag = "v1.16.6-anlog0", default-features = false }
 
 # specialized wasm builder
-substrate-wasm-builder = { git = "https://github.com/analog-labs/polkadot-sdk", tag = "v1.15.8-anlog0", features = [ "metadata-hash" ] }
+substrate-wasm-builder = { git = "https://github.com/analog-labs/polkadot-sdk", tag = "v1.16.6-anlog0", features = [ "metadata-hash" ] }
 
 # metadata based chain interaction
 subxt = { version = "0.40.0" }

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
           # Download associated rust toolchain from mozilla
           toolchain = fpkgs.fromToolchainName {
             name = toml.toolchain.channel;
-            sha256 = "s1RPtyvDGJaX/BisLT+ifVfuhDT1nZkZ1NcK8sbwELM=";
+            sha256 = "Hn2uaQzRLidAWpfmRwSRdImifGUCAb9HeAqTYFXWeQk=";
           };
 
           # Determine profile or use default

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -38,6 +38,7 @@ tracing.workspace = true
 
 bincode = "1.3.3"
 convert_case = "0.8.0"
+deranged = "=0.4.0"
 hex-literal.workspace = true
 secp256k1 = { version = "0.7", features = [
 	'hmac',
@@ -114,10 +115,6 @@ pallet-members = { workspace = true, optional = true }
 pallet-shards = { workspace = true, optional = true }
 pallet-tasks = { workspace = true, optional = true }
 
-# HASHI Bridge
-eth-bridge = { workspace = true, optional = true }
-deranged = "=0.4.0"
-
 [build-dependencies]
 clap.workspace = true
 
@@ -136,10 +133,7 @@ default = [ "std" ]
 std = [
 	"scale-codec/std",
 	"polkadot-sdk/std",
-	"eth-bridge?/std"
 ]
-# Enable bridge code
-bridge = [ "eth-bridge" ]
 # Runtime variants
 testnet = [
 	"time-primitives/testnet",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -70,8 +70,6 @@ polkadot-sdk = { workspace = true, features = [
 	"sc-network-sync",
 	"sc-offchain",
 	"sc-rpc",
-	"sc-rpc-api",
-	"sc-rpc-spec-v2",
 	"sc-service",
 	"sc-storage-monitor",
 	"sc-sync-state-rpc",
@@ -102,7 +100,7 @@ polkadot-sdk = { workspace = true, features = [
 ] }
 
 # node's rpc dependencies
-jsonrpsee = { version = "0.23.2", features = [ "server" ] }
+jsonrpsee = { version = "0.24.9", features = [ "server" ] }
 
 # node's local dependencies
 time-primitives.workspace = true

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -17,7 +17,6 @@ use sc_consensus_grandpa::{
 	FinalityProofProvider, GrandpaJustificationStream, SharedAuthoritySet, SharedVoterState,
 };
 pub use sc_rpc::SubscriptionTaskExecutor;
-pub use sc_rpc_api::DenyUnsafe;
 use sc_transaction_pool_api::TransactionPool;
 
 use sp_api::ProvideRuntimeApi;
@@ -61,8 +60,6 @@ pub struct FullDeps<C, P, SC, B> {
 	pub select_chain: SC,
 	/// A copy of the chain spec.
 	pub chain_spec: Box<dyn sc_chain_spec::ChainSpec>,
-	/// Whether to deny unsafe calls
-	pub deny_unsafe: DenyUnsafe,
 	/// BABE specific dependencies.
 	pub babe: BabeDeps,
 	/// GRANDPA specific dependencies.
@@ -78,7 +75,6 @@ pub fn create_full<C, P, SC, B>(
 		pool,
 		select_chain,
 		chain_spec,
-		deny_unsafe,
 		babe,
 		grandpa,
 		backend,
@@ -106,7 +102,6 @@ where
 	use sc_consensus_babe_rpc::{Babe, BabeApiServer};
 	use sc_consensus_grandpa_rpc::{Grandpa, GrandpaApiServer};
 	use sc_rpc::dev::{Dev, DevApiServer};
-	use sc_rpc_spec_v2::chain_spec::{ChainSpec, ChainSpecApiServer};
 	use sc_sync_state_rpc::{SyncState, SyncStateApiServer};
 	use substrate_frame_rpc_system::{System, SystemApiServer};
 	use substrate_state_trie_migration_rpc::{StateMigration, StateMigrationApiServer};
@@ -122,16 +117,10 @@ where
 		finality_provider,
 	} = grandpa;
 
-	let chain_name = chain_spec.name().to_string();
-	let genesis_hash = client.block_hash(0).ok().flatten().expect("Genesis block exists; qed");
-	let properties = chain_spec.properties();
-	io.merge(ChainSpec::new(chain_name, genesis_hash, properties).into_rpc())?;
-
-	io.merge(System::new(client.clone(), pool, deny_unsafe).into_rpc())?;
+	io.merge(System::new(client.clone(), pool).into_rpc())?;
 	io.merge(TransactionPayment::new(client.clone()).into_rpc())?;
 	io.merge(
-		Babe::new(client.clone(), babe_worker_handle.clone(), keystore, select_chain, deny_unsafe)
-			.into_rpc(),
+		Babe::new(client.clone(), babe_worker_handle.clone(), keystore, select_chain).into_rpc(),
 	)?;
 	io.merge(
 		Grandpa::new(
@@ -149,8 +138,8 @@ where
 			.into_rpc(),
 	)?;
 
-	io.merge(StateMigration::new(client.clone(), backend, deny_unsafe).into_rpc())?;
-	io.merge(Dev::new(client, deny_unsafe).into_rpc())?;
+	io.merge(StateMigration::new(client.clone(), backend).into_rpc())?;
+	io.merge(Dev::new(client).into_rpc())?;
 
 	Ok(io)
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -33,7 +33,7 @@ use sc_consensus_babe::{self, SlotProportion};
 use sc_network::{
 	event::Event, service::traits::NetworkService, NetworkBackend, NetworkEventStream,
 };
-use sc_network_sync::{strategy::warp::WarpSyncParams, SyncingService};
+use sc_network_sync::{strategy::warp::WarpSyncConfig, SyncingService};
 use sc_service::{config::Configuration, error::Error as ServiceError, RpcHandlers, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryWorker};
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
@@ -86,7 +86,6 @@ pub fn new_partial<RuntimeApi>(
 		sc_transaction_pool::FullPool<Block, FullClient<RuntimeApi>>,
 		(
 			impl Fn(
-				rpc::DenyUnsafe,
 				sc_rpc::SubscriptionTaskExecutor,
 			) -> Result<jsonrpsee::RpcModule<()>, sc_service::Error>,
 			(
@@ -124,7 +123,7 @@ where
 		})
 		.transpose()?;
 
-	let executor = sc_service::new_wasm_executor(config);
+	let executor = sc_service::new_wasm_executor(&config.executor);
 
 	let (client, backend, keystore_container, task_manager) =
 		sc_service::new_full_parts::<Block, RuntimeApi, _>(
@@ -289,30 +288,28 @@ where
 		let chain_spec = config.chain_spec.cloned_box();
 
 		let rpc_backend = backend.clone();
-		let rpc_extensions_builder =
-			move |deny_unsafe, subscription_executor: rpc::SubscriptionTaskExecutor| {
-				let deps = rpc::FullDeps {
-					client: client.clone(),
-					pool: pool.clone(),
-					select_chain: select_chain.clone(),
-					chain_spec: chain_spec.cloned_box(),
-					deny_unsafe,
-					babe: rpc::BabeDeps {
-						keystore: keystore.clone(),
-						babe_worker_handle: babe_worker_handle.clone(),
-					},
-					grandpa: rpc::GrandpaDeps {
-						shared_voter_state: shared_voter_state.clone(),
-						shared_authority_set: shared_authority_set.clone(),
-						justification_stream: justification_stream.clone(),
-						subscription_executor: subscription_executor.clone(),
-						finality_provider: finality_proof_provider.clone(),
-					},
-					backend: rpc_backend.clone(),
-				};
-
-				rpc::create_full(deps).map_err(Into::into)
+		let rpc_extensions_builder = move |subscription_executor: rpc::SubscriptionTaskExecutor| {
+			let deps = rpc::FullDeps {
+				client: client.clone(),
+				pool: pool.clone(),
+				select_chain: select_chain.clone(),
+				chain_spec: chain_spec.cloned_box(),
+				babe: rpc::BabeDeps {
+					keystore: keystore.clone(),
+					babe_worker_handle: babe_worker_handle.clone(),
+				},
+				grandpa: rpc::GrandpaDeps {
+					shared_voter_state: shared_voter_state.clone(),
+					shared_authority_set: shared_authority_set.clone(),
+					justification_stream: justification_stream.clone(),
+					subscription_executor: subscription_executor.clone(),
+					finality_provider: finality_proof_provider.clone(),
+				},
+				backend: rpc_backend.clone(),
 			};
+
+			rpc::create_full(deps).map_err(Into::into)
+		};
 
 		(rpc_extensions_builder, shared_voter_state2)
 	};
@@ -377,7 +374,7 @@ where
 		+ sp_session::SessionKeys<Block>
 		+ sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>,
 {
-	let role = config.role.clone();
+	let role = config.role;
 	let force_authoring = config.force_authoring;
 	let backoff_authoring_blocks =
 		Some(sc_consensus_slots::BackoffAuthoringOnFinalizedHeadLagging::default());
@@ -389,7 +386,7 @@ where
 	let hwbench = (!disable_hardware_benchmarks)
 		.then_some(config.database.path().map(|database_path| {
 			let _ = std::fs::create_dir_all(database_path);
-			sc_sysinfo::gather_hwbench(Some(database_path))
+			sc_sysinfo::gather_hwbench(Some(database_path), &SUBSTRATE_REFERENCE_HARDWARE)
 		}))
 		.flatten();
 
@@ -411,8 +408,10 @@ where
 	let auth_disc_publish_non_global_ips = config.network.allow_non_globals_in_dht;
 	let auth_disc_public_addresses = config.network.public_addresses.clone();
 
-	let mut net_config =
-		sc_network::config::FullNetworkConfiguration::<_, _, Network>::new(&config.network);
+	let mut net_config = sc_network::config::FullNetworkConfiguration::<_, _, Network>::new(
+		&config.network,
+		config.prometheus_config.as_ref().map(|cfg| cfg.registry.clone()),
+	);
 
 	let genesis_hash = client.block_hash(0).ok().flatten().expect("Genesis block exists; qed");
 	let peer_store_handle = net_config.peer_store_handle();
@@ -442,7 +441,7 @@ where
 			spawn_handle: task_manager.spawn_handle(),
 			import_queue,
 			block_announce_validator_builder: None,
-			warp_sync_params: Some(WarpSyncParams::WithProvider(warp_sync)),
+			warp_sync_config: Some(WarpSyncConfig::WithProvider(warp_sync)),
 			block_relay: None,
 			metrics,
 		})?;
@@ -464,7 +463,7 @@ where
 
 	if let Some(hwbench) = hwbench {
 		sc_sysinfo::print_hwbench(&hwbench);
-		match SUBSTRATE_REFERENCE_HARDWARE.check_hardware(&hwbench) {
+		match SUBSTRATE_REFERENCE_HARDWARE.check_hardware(&hwbench, false) {
 			Err(err) if role.is_authority() => {
 				log::warn!(
 					"⚠️  The hardware does not meet the minimal requirements {} for role 'Authority'.",
@@ -576,7 +575,7 @@ where
 		name: Some(name),
 		observer_enabled: false,
 		keystore,
-		local_role: role.clone(),
+		local_role: role,
 		telemetry: telemetry.as_ref().map(|x| x.handle()),
 		protocol_name: grandpa_protocol_name,
 	};

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -9,24 +9,6 @@ use std::{path::Path, sync::Arc};
 
 use polkadot_sdk::*;
 
-#[cfg(feature = "bridge")]
-use eth_bridge::{
-	common, PeerConfig, STORAGE_ETH_NODE_PARAMS, STORAGE_NETWORK_IDS_KEY, STORAGE_PEER_SECRET_KEY,
-	STORAGE_SUB_NODE_URL_KEY,
-};
-#[cfg(feature = "bridge")]
-use scale_codec::Encode;
-#[cfg(feature = "bridge")]
-use sp_core::{offchain::OffchainStorage, ByteArray, Pair};
-#[cfg(feature = "bridge")]
-use sp_runtime::{offchain::STORAGE_PREFIX, traits::IdentifyAccount};
-#[cfg(feature = "bridge")]
-use sp_std::collections::btree_set::BTreeSet;
-#[cfg(feature = "bridge")]
-use std::fs::File;
-#[cfg(feature = "bridge")]
-use timechain_runtime::Runtime;
-
 use frame_benchmarking_cli::SUBSTRATE_REFERENCE_HARDWARE;
 use sc_client_api::{Backend, BlockBackend};
 use sc_consensus_babe::{self, SlotProportion};
@@ -132,84 +114,6 @@ where
 			executor,
 		)?;
 	let client = Arc::new(client);
-
-	#[cfg(feature = "bridge")]
-	{
-		// HASHI Bridge support
-		let mut bridge_peer_secret_key = None;
-
-		if let Some(first_pk_raw) = keystore_container
-			.keystore()
-			.keys(eth_bridge::KEY_TYPE)
-			.unwrap()
-			.first()
-			.cloned()
-		{
-			let pk = eth_bridge::offchain::crypto::Public::from_slice(&first_pk_raw[..])
-				.expect("should have correct size");
-			let sub_public = sp_core::ecdsa::Public::from(pk.clone());
-			let public = secp256k1::PublicKey::parse_compressed(&sub_public.0).unwrap();
-			let address = common::eth::public_key_to_eth_address(&public);
-			let account = sp_runtime::MultiSigner::Ecdsa(sub_public).into_account();
-			log::warn!(
-				"Peer info: address: {:?}, account: {:?}, {}, public: {:?}",
-				address,
-				account,
-				account,
-				sub_public
-			);
-			let keystore = keystore_container.local_keystore();
-			if let Ok(Some(kep)) = keystore.key_pair::<eth_bridge::offchain::crypto::Pair>(&pk) {
-				let seed = kep.to_raw_vec();
-				bridge_peer_secret_key = Some(seed);
-			}
-		} else {
-			log::debug!("Ethereum bridge peer key not found.")
-		}
-
-		if let Some(sk) = bridge_peer_secret_key {
-			let mut storage = backend.offchain_storage().unwrap();
-			storage.set(STORAGE_PREFIX, STORAGE_PEER_SECRET_KEY, &sk.encode());
-
-			let path = config
-				.network
-				.net_config_path
-				.clone()
-				.or(config.database.path().map(|x| x.to_owned()))
-				.expect("Expected network or database path.");
-			let bridge_path = path
-				.ancestors()
-				.nth(1)
-				.map(|x| {
-					let mut x = x.to_owned();
-					x.push("bridge/eth.json");
-					x
-				})
-				.unwrap();
-			let file = File::open(&bridge_path).map_err(|_| {
-				ServiceError::Other(format!(
-					"Ethereum bridge node config not found. Expected path: {:?}",
-					bridge_path
-				))
-			})?;
-			let peer_config: PeerConfig<<Runtime as eth_bridge::Config>::NetworkId> =
-				serde_json::from_reader(&file).expect("Invalid ethereum bridge node config.");
-			let mut network_ids = BTreeSet::new();
-			for (net_id, params) in peer_config.networks {
-				let string = format!("{}-{:?}", STORAGE_ETH_NODE_PARAMS, net_id);
-				storage.set(STORAGE_PREFIX, string.as_bytes(), &params.encode());
-				network_ids.insert(net_id);
-			}
-			storage.set(STORAGE_PREFIX, STORAGE_NETWORK_IDS_KEY, &network_ids.encode());
-			let addr = config.rpc_addr.unwrap_or_else(|| ([127, 0, 0, 1], config.rpc_port).into());
-			log::warn!("RPC Address: {addr}");
-			storage.set(
-				STORAGE_PREFIX,
-				STORAGE_SUB_NODE_URL_KEY,
-				&format!("http://{}", addr).encode(),
-			);
-		}
-	}
 
 	let telemetry = telemetry.map(|(worker, telemetry)| {
 		task_manager.spawn_handle().spawn("telemetry", None, worker.run());

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,7 +21,6 @@ separator = "0.4.1"
 [dependencies]
 log = { workspace = true }
 
-hex-literal.workspace = true
 smallvec = "1.14.0"
 
 scale-codec = { workspace = true, features = [ "max-encoded-len" ] }

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -273,6 +273,14 @@ impl_runtime_apis! {
 		fn member_needs_delegate_migration(member: AccountId) -> bool {
 			NominationPools::api_member_needs_delegate_migration(member)
 		}
+
+		fn member_total_balance(who: AccountId) -> Balance {
+			NominationPools::api_member_total_balance(who)
+		}
+
+		fn pool_balance(pool_id: pallet_nomination_pools::PoolId) -> Balance {
+			NominationPools::api_pool_balance(pool_id)
+		}
 	}
 
 	impl pallet_staking_runtime_api::StakingApi<Block, Balance, AccountId> for Runtime {

--- a/runtime/src/configs/tokenomics.rs
+++ b/runtime/src/configs/tokenomics.rs
@@ -163,7 +163,7 @@ impl OnUnbalanced<NegativeImbalance> for Author {
 pub struct DealWithFees;
 #[cfg(feature = "testnet")]
 impl OnUnbalanced<NegativeImbalance> for DealWithFees {
-	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
+	fn on_unbalanceds(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
 		if let Some(fees) = fees_then_tips.next() {
 			// for fees, 80% to treasury, 20% to author
 			let mut split = fees.ration(80, 20);

--- a/runtime/src/weights/develop/pallet_networks.rs
+++ b/runtime/src/weights/develop/pallet_networks.rs
@@ -70,8 +70,7 @@ impl<T: frame_system::Config> pallet_networks::WeightInfo for WeightInfo<T> {
 	/// Storage: `Tasks::TaskNetwork` (r:0 w:1)
 	/// Proof: `Tasks::TaskNetwork` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// The range of component `a` is `[1, 50]`.
-	/// The range of component `b` is `[1, 50]`.
-	fn register_network(a: u32) -> Weight {
+	fn register_network(a: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `189`
 		//  Estimated: `3654`

--- a/runtime/src/weights/mainnet/pallet_networks.rs
+++ b/runtime/src/weights/mainnet/pallet_networks.rs
@@ -64,10 +64,7 @@ impl<T: frame_system::Config> pallet_networks::WeightInfo for WeightInfo<T> {
 	/// Storage: `Tasks::TaskNetwork` (r:0 w:1)
 	/// Proof: `Tasks::TaskNetwork` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// The range of component `a` is `[1, 50]`.
-	/// The range of component `b` is `[1, 50]`.
-	/// The range of component `a` is `[1, 50]`.
-	/// The range of component `b` is `[1, 50]`.
-	fn register_network(a: u32, b: u32, ) -> Weight {
+	fn register_network(a: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `118`
 		//  Estimated: `3583`

--- a/runtime/src/weights/testnet/pallet_networks.rs
+++ b/runtime/src/weights/testnet/pallet_networks.rs
@@ -70,10 +70,7 @@ impl<T: frame_system::Config> pallet_networks::WeightInfo for WeightInfo<T> {
 	/// Storage: `Tasks::TaskNetwork` (r:0 w:1)
 	/// Proof: `Tasks::TaskNetwork` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// The range of component `a` is `[1, 50]`.
-	/// The range of component `b` is `[1, 50]`.
-	/// The range of component `c` is `[1, 50]`.
-	/// The range of component `d` is `[1, 200]`.
-	fn register_network(_a: u32, _b: u32, ) -> Weight {
+	fn register_network(_a: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `189`
 		//  Estimated: `3654`

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -3,6 +3,8 @@
 set -e
 set -x
 
+RUSTFLAGS=""
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 WORKSPACE_ROOT=$SCRIPT_DIR/../
 cd $WORKSPACE_ROOT
@@ -15,6 +17,10 @@ docker info > /dev/null 2>&1 || { echo >&2 "ERROR - requires 'docker', please st
 
 # Check for 'rustup' and abort if it is not available.
 rustup -V > /dev/null 2>&1 || { echo >&2 "ERROR - requires 'rustup' for compile the binaries"; exit 1; }
+
+if command -v lld 2>&1 >/dev/null; then
+	RUSTFLAGS="-C link-arg=-fuse-ld=lld ${RUSTFLAGS:-}"
+fi
 
 # Detect host architecture
 case "$(uname -m)" in
@@ -70,7 +76,7 @@ fi
 
 # Build docker image
 forge build --root analog-gmp
-cargo build -p timechain-node -p chronicle -p tc-cli -p gmp-grpc --target "$rustTarget" --profile "$profile" --features "$features"
+RUSTFLAGS=$RUSTFLAGS cargo build -p timechain-node -p chronicle -p tc-cli -p gmp-grpc --target "$rustTarget" --profile "$profile" --features "$features"
 
 mkdir -p $WORKSPACE_ROOT/target/docker/tc-cli
 mkdir -p $WORKSPACE_ROOT/target/docker/chronicle

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-RUSTFLAGS=""
+RUSTFLAGS="${RUSTFLAGS:-}"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 WORKSPACE_ROOT=$SCRIPT_DIR/../
@@ -19,7 +19,7 @@ docker info > /dev/null 2>&1 || { echo >&2 "ERROR - requires 'docker', please st
 rustup -V > /dev/null 2>&1 || { echo >&2 "ERROR - requires 'rustup' for compile the binaries"; exit 1; }
 
 if command -v lld 2>&1 >/dev/null; then
-	RUSTFLAGS="-C link-arg=-fuse-ld=lld ${RUSTFLAGS:-}"
+    RUSTFLAGS="-C link-arg=-fuse-ld=lld ${RUSTFLAGS}"
 fi
 
 # Detect host architecture
@@ -74,9 +74,11 @@ if ! rustup target list | grep -q "$rustTarget"; then
   rustup target add "$rustTarget"
 fi
 
+export RUSTFLAGS
+
 # Build docker image
 forge build --root analog-gmp
-RUSTFLAGS=$RUSTFLAGS cargo build -p timechain-node -p chronicle -p tc-cli -p gmp-grpc --target "$rustTarget" --profile "$profile" --features "$features"
+cargo build -p timechain-node -p chronicle -p tc-cli -p gmp-grpc --target "$rustTarget" --profile "$profile" --features "$features"
 
 mkdir -p $WORKSPACE_ROOT/target/docker/tc-cli
 mkdir -p $WORKSPACE_ROOT/target/docker/chronicle


### PR DESCRIPTION
This updates the polkadot-sdk to the next release. There is a more current release, but we want to take it one release at the time.

This is a perquisite for some upcoming staking and evm work.