### PR TITLE
docker: update base images, add chronicle chain list

### DIFF
--- a/config/docker/Dockerfile.chronicle-release
+++ b/config/docker/Dockerfile.chronicle-release
@@ -1,4 +1,4 @@
-FROM rust:1.81.0 AS builder
+FROM rust:1.85.1 AS builder
 
 ARG PROFILE
 ARG FEATURES=default
@@ -25,4 +25,5 @@ LABEL description="Multistage Dockerfile for building Analog Chronicle" \
 	one.analog.image.source="https://github.com/Analog-Labs/timechain" \
 	one.analog.image.commit="${VCS_REF}"
 COPY --from=builder /build/bin/chronicle chronicle
+COPY gmp/evm/auxiliary/chains.json /etc/chain-config/chains.json
 ENTRYPOINT ["/chronicle"]

--- a/config/docker/Dockerfile.timenode-release
+++ b/config/docker/Dockerfile.timenode-release
@@ -1,6 +1,6 @@
 ### Build stage
 ### Uses custom substrate builder (Dockerfile in infra repo)
-FROM analoglabs/substrate-builder:1.81.0 as builder
+FROM analoglabs/substrate-builder:1.85.1 as builder
 
 ARG PROFILE
 ARG FEATURES=default


### PR DESCRIPTION
## Description

- updates base images for chronicle and timenode
- adds list of chains to the chronicle image