### PR TITLE
ci: invert logic for trigger paths

### DIFF
--- a/.github/workflows/merge-docker-chronicle.yaml
+++ b/.github/workflows/merge-docker-chronicle.yaml
@@ -1,17 +1,18 @@
 name: Build Docker chronicle image
 on:
   push:
-    paths:
-      - '.github/workflows/merge-docker-chronicle.yaml'
-      - 'chronicle/**'
-      - 'config/subxt/**'
-      - 'lib/**'
-      - 'primitives/**'
-      - 'tc-subxt/**'
-      - 'tss/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain.toml'
+    paths-ignore:
+      - '.github/**'
+      - '!.github/workflows/merge-docker-chronicle.yaml'
+      - '.cargo/**'
+      - 'config/**'
+      - '!config/docker/Dockerfile.chronicle-release'
+      - 'tc-cli/**'
+      - 'node'
+      - 'slack-bot/**'
+      - 'utils/**'
+      - 'e2e-tests/**'
+      - 'docs/**'
     branches:
       - "ci/binary/**"
       - 'development'

--- a/.github/workflows/merge-docker-tc-cli.yaml
+++ b/.github/workflows/merge-docker-tc-cli.yaml
@@ -1,16 +1,17 @@
 name: Build Docker tc-cli
 on:
   push:
-    paths:
-      - '.github/workflows/merge-docker-tc-cli.yaml'
-      - 'analog-gmp/**'
-      - 'config/envs/**'
-      - 'primitives/**'
-      - 'tc-subxt/**'
-      - 'tc-cli/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain.toml'
+    paths-ignore:
+      - '.github/**'
+      - '!.github/workflows/merge-docker-tc-cli.yaml'
+      - '.cargo/**'
+      - 'chronicle/**'
+      - 'docs/**'
+      - 'e2e-tests/**'
+      - 'node/**'
+      - 'tss/**'
+      - 'slack-bot/**'
+      - 'utils/**'
     branches:
       - 'development'
 concurrency:


### PR DESCRIPTION
## Description

This PR adds ignored paths to the tc-cli and chronicle builds. It's more maintainable because it's easier to let the CI build what's not necessary than adding paths which are dependencies and not triggering the CI.