### PR TITLE
Patch finish task panic

### DIFF
--- a/pallets/tasks/src/lib.rs
+++ b/pallets/tasks/src/lib.rs
@@ -538,7 +538,11 @@ pub mod pallet {
 			task_id
 		}
 
-		fn finish_task(network: NetworkId, task_id: TaskId, result: Result<(), ErrorMsg>) {
+		pub(crate) fn finish_task(
+			network: NetworkId,
+			task_id: TaskId,
+			result: Result<(), ErrorMsg>,
+		) {
 			TaskOutput::<T>::insert(task_id, result.clone());
 			if let Some(shard) = Some(TaskShard::<T>::take(task_id).unwrap()) {
 				log::debug!("finish task {task_id} on {shard}");

--- a/pallets/tasks/src/lib.rs
+++ b/pallets/tasks/src/lib.rs
@@ -471,7 +471,7 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
-		fn process_events(network: NetworkId, task_id: TaskId, events: GmpEvents) {
+		pub(crate) fn process_events(network: NetworkId, task_id: TaskId, events: GmpEvents) {
 			for event in events.0 {
 				match event {
 					GmpEvent::ShardRegistered(pubkey) => {
@@ -559,7 +559,7 @@ pub mod pallet {
 			Self::deposit_event(Event::TaskResult(task_id, result));
 		}
 
-		fn read_gateway_events(network: NetworkId) -> TaskId {
+		pub(crate) fn read_gateway_events(network: NetworkId) -> TaskId {
 			let block = SyncHeight::<T>::get(network);
 			let size = T::Networks::next_batch_size(network, block) as u64;
 			let end = block.saturating_add(size);

--- a/pallets/tasks/src/lib.rs
+++ b/pallets/tasks/src/lib.rs
@@ -543,6 +543,9 @@ pub mod pallet {
 			task_id: TaskId,
 			result: Result<(), ErrorMsg>,
 		) {
+			if TaskOutput::<T>::get(task_id).is_some() {
+				return;
+			}
 			TaskOutput::<T>::insert(task_id, result.clone());
 			if let Some(shard) = TaskShard::<T>::take(task_id) {
 				log::debug!("finish task {task_id} on {shard}");

--- a/pallets/tasks/src/lib.rs
+++ b/pallets/tasks/src/lib.rs
@@ -544,7 +544,7 @@ pub mod pallet {
 			result: Result<(), ErrorMsg>,
 		) {
 			TaskOutput::<T>::insert(task_id, result.clone());
-			if let Some(shard) = Some(TaskShard::<T>::take(task_id).unwrap()) {
+			if let Some(shard) = TaskShard::<T>::take(task_id) {
 				log::debug!("finish task {task_id} on {shard}");
 				ShardTasks::<T>::remove(shard, task_id);
 				ShardTaskCount::<T>::insert(

--- a/pallets/tasks/src/lib.rs
+++ b/pallets/tasks/src/lib.rs
@@ -543,7 +543,7 @@ pub mod pallet {
 			task_id: TaskId,
 			result: Result<(), ErrorMsg>,
 		) {
-			if TaskOutput::<T>::get(task_id).is_some() {
+			if TaskOutput::<T>::contains_key(task_id) {
 				return;
 			}
 			TaskOutput::<T>::insert(task_id, result.clone());

--- a/pallets/tasks/src/tests.rs
+++ b/pallets/tasks/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
 	mock::*, BatchIdCounter, BatchTaskId, BatchTxHash, Event, FailedBatchIds, ShardRegistered,
-	TaskShard,
+	TaskOutput, TaskShard,
 };
 
 use frame_support::assert_ok;
@@ -508,5 +508,65 @@ fn test_regression_finish_task_panic() {
 			read_task_id,
 			result
 		));
+	});
+}
+
+#[test]
+fn finish_task_overwrites_ok_with_err() {
+	new_test_ext().execute_with(|| {
+		register_gateway(ETHEREUM, 42);
+		let shard = create_shard(ETHEREUM, 3, 1);
+		roll(1);
+		let task_id = Tasks::create_task(ETHEREUM, Task::ReadGatewayEvents { blocks: 1..5 });
+		Tasks::assign_task(shard, task_id);
+		assert!(TaskShard::<Test>::contains_key(task_id));
+		Tasks::finish_task(ETHEREUM, task_id, Ok(()));
+		assert_eq!(TaskOutput::<Test>::get(task_id), Some(Ok(())));
+		assert!(!TaskShard::<Test>::contains_key(task_id));
+		let error_msg = ErrorMsg(BoundedVec::truncate_from("Second result with error".encode()));
+		Tasks::finish_task(ETHEREUM, task_id, Err(error_msg.clone()));
+		assert_eq!(TaskOutput::<Test>::get(task_id), Some(Err(error_msg.clone())));
+		let task_result_events = System::events()
+			.into_iter()
+			.filter_map(|r| {
+				if let RuntimeEvent::Tasks(Event::TaskResult(id, _)) = r.event {
+					if id == task_id {
+						return Some(id);
+					}
+				}
+				None
+			})
+			.count();
+		assert_eq!(task_result_events, 2);
+	});
+}
+
+#[test]
+fn finish_task_overwrites_err_with_ok() {
+	new_test_ext().execute_with(|| {
+		register_gateway(ETHEREUM, 42);
+		let shard = create_shard(ETHEREUM, 3, 1);
+		roll(1);
+		let task_id = Tasks::create_task(ETHEREUM, Task::ReadGatewayEvents { blocks: 1..5 });
+		Tasks::assign_task(shard, task_id);
+		assert!(TaskShard::<Test>::contains_key(task_id));
+		let error_msg = ErrorMsg(BoundedVec::truncate_from("First result with error".encode()));
+		Tasks::finish_task(ETHEREUM, task_id, Err(error_msg.clone()));
+		assert_eq!(TaskOutput::<Test>::get(task_id), Some(Err(error_msg.clone())));
+		assert!(!TaskShard::<Test>::contains_key(task_id));
+		Tasks::finish_task(ETHEREUM, task_id, Ok(()));
+		assert_eq!(TaskOutput::<Test>::get(task_id), Some(Ok(())));
+		let task_result_events = System::events()
+			.into_iter()
+			.filter_map(|r| {
+				if let RuntimeEvent::Tasks(Event::TaskResult(id, _)) = r.event {
+					if id == task_id {
+						return Some(id);
+					}
+				}
+				None
+			})
+			.count();
+		assert_eq!(task_result_events, 2);
 	});
 }

--- a/pallets/tasks/src/tests.rs
+++ b/pallets/tasks/src/tests.rs
@@ -472,7 +472,6 @@ fn finish_task_removes_task_shard() {
 		let batch_id = BatchIdCounter::<Test>::get();
 		let task_id = Tasks::create_task(ETHEREUM, Task::SubmitGatewayMessage { batch_id });
 		BatchTaskId::<Test>::insert(batch_id, task_id);
-		// Assign the task to the shard
 		Tasks::assign_task(shard, task_id);
 		assert!(TaskShard::<Test>::contains_key(task_id), "Task should be assigned to a shard");
 		Tasks::finish_task(ETHEREUM, task_id, Ok(()));

--- a/pallets/tasks/src/tests.rs
+++ b/pallets/tasks/src/tests.rs
@@ -464,7 +464,7 @@ mod bench_helper {
 }
 
 #[test]
-fn show_finish_task_bug() {
+fn finish_task_removes_task_shard() {
 	new_test_ext().execute_with(|| {
 		register_gateway(ETHEREUM, 42);
 		let shard = create_shard(ETHEREUM, 3, 1);
@@ -475,11 +475,38 @@ fn show_finish_task_bug() {
 		// Assign the task to the shard
 		Tasks::assign_task(shard, task_id);
 		assert!(TaskShard::<Test>::contains_key(task_id), "Task should be assigned to a shard");
-
-		// Call finish_task to simulate what happens in process_events to remove the task assignment from storage
 		Tasks::finish_task(ETHEREUM, task_id, Ok(()));
-		// TaskShard::get returns None which would cause unwrap() to panic in finish_task if called again in this line:
-		// if let Some(shard) = Some(TaskShard::<T>::take(task_id).unwrap()) { ... }
 		assert!(!TaskShard::<Test>::contains_key(task_id));
+	});
+}
+
+#[test]
+fn test_regression_finish_task_panic() {
+	new_test_ext().execute_with(|| {
+		register_gateway(ETHEREUM, 42);
+		let shard = create_shard(ETHEREUM, 3, 1);
+		roll(1);
+		let batch_id = BatchIdCounter::<Test>::get();
+		let batch_task_id = Tasks::create_task(ETHEREUM, Task::SubmitGatewayMessage { batch_id });
+		BatchTaskId::<Test>::insert(batch_id, batch_task_id);
+		Tasks::assign_task(shard, batch_task_id);
+		assert!(TaskShard::<Test>::contains_key(batch_task_id));
+		let read_task_id = Tasks::read_gateway_events(ETHEREUM);
+		Tasks::assign_task(shard, read_task_id);
+		BatchTaskId::<Test>::insert(batch_id, read_task_id);
+		let events = vec![GmpEvent::BatchExecuted {
+			batch_id,
+			tx_hash: Some([1; 32]),
+		}];
+		let signature = MockTssSigner::new(shard).sign_gmp_events(read_task_id, &events);
+		let result = TaskResult::ReadGatewayEvents {
+			events: GmpEvents(BoundedVec::truncate_from(events)),
+			signature,
+		};
+		assert_ok!(Tasks::submit_task_result(
+			RawOrigin::Signed([0; 32].into()).into(),
+			read_task_id,
+			result
+		));
 	});
 }

--- a/pallets/tasks/src/tests.rs
+++ b/pallets/tasks/src/tests.rs
@@ -511,7 +511,7 @@ fn test_regression_finish_task_does_not_panic() {
 }
 
 #[test]
-fn finish_task_overwrites_ok_with_err() {
+fn finish_task_keeps_result_ok_after_err() {
 	new_test_ext().execute_with(|| {
 		register_gateway(ETHEREUM, 42);
 		let shard = create_shard(ETHEREUM, 3, 1);
@@ -524,36 +524,6 @@ fn finish_task_overwrites_ok_with_err() {
 		assert!(!TaskShard::<Test>::contains_key(task_id));
 		let error_msg = ErrorMsg(BoundedVec::truncate_from("Second result with error".encode()));
 		Tasks::finish_task(ETHEREUM, task_id, Err(error_msg.clone()));
-		assert_eq!(TaskOutput::<Test>::get(task_id), Some(Err(error_msg.clone())));
-		let task_result_events = System::events()
-			.into_iter()
-			.filter_map(|r| {
-				if let RuntimeEvent::Tasks(Event::TaskResult(id, _)) = r.event {
-					if id == task_id {
-						return Some(id);
-					}
-				}
-				None
-			})
-			.count();
-		assert_eq!(task_result_events, 2);
-	});
-}
-
-#[test]
-fn finish_task_overwrites_err_with_ok() {
-	new_test_ext().execute_with(|| {
-		register_gateway(ETHEREUM, 42);
-		let shard = create_shard(ETHEREUM, 3, 1);
-		roll(1);
-		let task_id = Tasks::create_task(ETHEREUM, Task::ReadGatewayEvents { blocks: 1..5 });
-		Tasks::assign_task(shard, task_id);
-		assert!(TaskShard::<Test>::contains_key(task_id));
-		let error_msg = ErrorMsg(BoundedVec::truncate_from("First result with error".encode()));
-		Tasks::finish_task(ETHEREUM, task_id, Err(error_msg.clone()));
-		assert_eq!(TaskOutput::<Test>::get(task_id), Some(Err(error_msg.clone())));
-		assert!(!TaskShard::<Test>::contains_key(task_id));
-		Tasks::finish_task(ETHEREUM, task_id, Ok(()));
 		assert_eq!(TaskOutput::<Test>::get(task_id), Some(Ok(())));
 		let task_result_events = System::events()
 			.into_iter()
@@ -566,6 +536,36 @@ fn finish_task_overwrites_err_with_ok() {
 				None
 			})
 			.count();
-		assert_eq!(task_result_events, 2);
+		assert_eq!(task_result_events, 1);
+	});
+}
+
+#[test]
+fn finish_task_keeps_result_err_after_ok() {
+	new_test_ext().execute_with(|| {
+		register_gateway(ETHEREUM, 42);
+		let shard = create_shard(ETHEREUM, 3, 1);
+		roll(1);
+		let task_id = Tasks::create_task(ETHEREUM, Task::ReadGatewayEvents { blocks: 1..5 });
+		Tasks::assign_task(shard, task_id);
+		assert!(TaskShard::<Test>::contains_key(task_id));
+		let error_msg = ErrorMsg(BoundedVec::truncate_from("First result with error".encode()));
+		Tasks::finish_task(ETHEREUM, task_id, Err(error_msg.clone()));
+		assert_eq!(TaskOutput::<Test>::get(task_id), Some(Err(error_msg.clone())));
+		assert!(!TaskShard::<Test>::contains_key(task_id));
+		Tasks::finish_task(ETHEREUM, task_id, Ok(()));
+		assert_eq!(TaskOutput::<Test>::get(task_id), Some(Err(error_msg.clone())));
+		let task_result_events = System::events()
+			.into_iter()
+			.filter_map(|r| {
+				if let RuntimeEvent::Tasks(Event::TaskResult(id, _)) = r.event {
+					if id == task_id {
+						return Some(id);
+					}
+				}
+				None
+			})
+			.count();
+		assert_eq!(task_result_events, 1);
 	});
 }

--- a/pallets/tasks/src/tests.rs
+++ b/pallets/tasks/src/tests.rs
@@ -481,7 +481,7 @@ fn finish_task_removes_task_shard() {
 }
 
 #[test]
-fn test_regression_finish_task_panic() {
+fn test_regression_finish_task_does_not_panic() {
 	new_test_ext().execute_with(|| {
 		register_gateway(ETHEREUM, 42);
 		let shard = create_shard(ETHEREUM, 3, 1);

--- a/pallets/tasks/src/tests.rs
+++ b/pallets/tasks/src/tests.rs
@@ -462,3 +462,24 @@ mod bench_helper {
 		panic!();
 	}
 }
+
+#[test]
+fn show_finish_task_bug() {
+	new_test_ext().execute_with(|| {
+		register_gateway(ETHEREUM, 42);
+		let shard = create_shard(ETHEREUM, 3, 1);
+		roll(1);
+		let batch_id = BatchIdCounter::<Test>::get();
+		let task_id = Tasks::create_task(ETHEREUM, Task::SubmitGatewayMessage { batch_id });
+		BatchTaskId::<Test>::insert(batch_id, task_id);
+		// Assign the task to the shard
+		Tasks::assign_task(shard, task_id);
+		assert!(TaskShard::<Test>::contains_key(task_id), "Task should be assigned to a shard");
+
+		// Call finish_task to simulate what happens in process_events to remove the task assignment from storage
+		Tasks::finish_task(ETHEREUM, task_id, Ok(()));
+		// TaskShard::get returns None which would cause unwrap() to panic in finish_task if called again in this line:
+		// if let Some(shard) = Some(TaskShard::<T>::take(task_id).unwrap()) { ... }
+		assert!(!TaskShard::<Test>::contains_key(task_id));
+	});
+}


### PR DESCRIPTION
Closes #1763 

The panic is an edge case which happens when the read task ID is equal to the batch task ID. This causes finish_task to be called twice as a consequence of a single call to `submit_task_result`.

Fixes:
- [x] remove panic from calling finish_task twice as consequence of a single submit_task_result call
- [x] keep the first result submitted to finish_task and ignore the second call to it for the edge case described (because the first result is the consequence of processing the event while the second is a user-submitted result)

Tests:
- [x] unit test showing that TaskShard is cleared as a result of finish_task (unchanged yet expected behavior)
- [x] regression test showing that submit_task_result panics in the edge case described at the top of this description
- [x] regression test showing that the first result is kept in storage and only its associated event is emitted

Follow up discussion/issue: https://github.com/Analog-Labs/timechain/issues/1766