### PR TITLE
Replace get.is_some --> contains_key in pallets

### DIFF
--- a/pallets/members/src/lib.rs
+++ b/pallets/members/src/lib.rs
@@ -349,11 +349,11 @@ pub mod pallet {
 
 		/// Checks if a specific member is online.
 		fn is_member_online(account: &AccountId) -> bool {
-			MemberOnline::<T>::get(account).is_some()
+			MemberOnline::<T>::contains_key(account)
 		}
 
 		fn is_member_registered(account: &AccountId) -> bool {
-			MemberRegistered::<T>::get(account).is_some()
+			MemberRegistered::<T>::contains_key(account)
 		}
 
 		fn do_unregister_member(account: &AccountId) {

--- a/pallets/networks/src/lib.rs
+++ b/pallets/networks/src/lib.rs
@@ -212,7 +212,7 @@ pub mod pallet {
 			network: NetworkId,
 			config: NetworkConfig,
 		) -> Result<(), Error<T>> {
-			ensure!(Networks::<T>::get(network).is_some(), Error::<T>::NetworkNotFound);
+			ensure!(Networks::<T>::contains_key(network), Error::<T>::NetworkNotFound);
 			ensure!(
 				time_primitives::MAX_SHARD_SIZE as u16 >= config.shard_size,
 				Error::<T>::ShardSizeAboveMax

--- a/pallets/shards/src/lib.rs
+++ b/pallets/shards/src/lib.rs
@@ -601,7 +601,7 @@ pub mod pallet {
 		///   1. Retrieves the shard `ID` associated with the member account from [`MemberShard`].
 		///   2. Returns `true` if the shard `ID` is present (`Some`), indicating the account is a member; otherwise, returns `false`.
 		fn is_shard_member(member: &AccountId) -> bool {
-			MemberShard::<T>::get(member).is_some()
+			MemberShard::<T>::contains_key(member)
 		}
 		/// Retrieves the network identifier associated with a specified shard.
 		///

--- a/pallets/tasks/src/lib.rs
+++ b/pallets/tasks/src/lib.rs
@@ -351,7 +351,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let signer = ensure_signed(origin)?;
 			let task = Tasks::<T>::get(task_id).ok_or(Error::<T>::UnknownTask)?;
-			if TaskOutput::<T>::get(task_id).is_some() {
+			if TaskOutput::<T>::contains_key(task_id) {
 				return Ok(());
 			}
 			let shard = TaskShard::<T>::get(task_id).ok_or(Error::<T>::UnassignedTask)?;
@@ -370,7 +370,7 @@ pub mod pallet {
 						SyncHeight::<T>::insert(network, blocks.end);
 					}
 					// start next batch if network wasn't stopped
-					if ReadEventsTask::<T>::get(network).is_some() {
+					if ReadEventsTask::<T>::contains_key(network) {
 						Self::read_gateway_events(network);
 					}
 					// process events
@@ -582,7 +582,7 @@ pub mod pallet {
 			let Some(pubkey) = T::Shards::tss_public_key(shard) else {
 				return false;
 			};
-			ShardRegistered::<T>::get(pubkey).is_some()
+			ShardRegistered::<T>::contains_key(pubkey)
 		}
 
 		pub(crate) fn assign_task(shard: ShardId, task_id: TaskId) {


### PR DESCRIPTION
Replaces get().is_some() with contains_key() in all pallets, I think I got all the cases that exist.

This is an optimization that @agryaznov raised during another PR's review. It is an optimization because contains_key checks for existence without decoding the value while get() reads and decodes the value which is unnecessary when it is not being used in the logic thereafter