### PR TITLE
Try to fix task stuck on error in evm connector

### DIFF
--- a/gmp/evm/src/lib.rs
+++ b/gmp/evm/src/lib.rs
@@ -343,7 +343,7 @@ impl IConnector for Connector {
 		let estimated_gas = gw_call.estimate_gas().await.map_err(|err| err.to_string())?;
 		let max_gas = std::cmp::max(estimated_gas, gas_limit);
 
-		let tx_hash = gw_call
+		let receipt = gw_call
 			.gas(max_gas)
 			.send()
 			.await
@@ -351,11 +351,19 @@ impl IConnector for Connector {
 				tracing::info!("failed to submit batch: {:?}", err);
 				err.to_string()
 			})?
-			.watch()
+			.with_timeout(Some(Duration::from_secs(DEFAULT_TX_TIMEOUT)))
+			.get_receipt()
 			.await
 			.map_err(|err| err.to_string())?;
+		let tx_hash = receipt.transaction_hash;
 
-		tracing::info!("batch {batch} submitted with tx: {tx_hash}");
+		if !receipt.inner.inner.is_success() {
+			let err = format!("batch {batch} failed with tx: {tx_hash}");
+			tracing::error!(err);
+			return Err(err.into());
+		} else {
+			tracing::info!("batch {batch} submitted with tx: {tx_hash}");
+		}
 
 		Ok(())
 	}
@@ -426,7 +434,7 @@ impl IConnectorAdmin for Connector {
 			.send_transaction(WithOtherFields::new(tx))
 			.await?
 			.with_timeout(Some(Duration::from_secs(DEFAULT_TX_TIMEOUT)))
-			.watch()
+			.get_receipt()
 			.await?;
 
 		Ok(())
@@ -752,8 +760,9 @@ impl Connector {
 			.send_raw_transaction(&encoded_tx)
 			.await?
 			.with_timeout(Some(Duration::from_secs(DEFAULT_TX_TIMEOUT)))
-			.watch()
-			.await?;
+			.get_receipt()
+			.await?
+			.transaction_hash;
 		tracing::info!("factory deployed with tx {tx_hash}");
 
 		Ok(())


### PR DESCRIPTION
Replaces alloy watch with `get_receipt`

fixes: https://github.com/Analog-Labs/timechain/issues/1828