### PR TITLE
Minimize gas costs for PolkaVM

### DIFF
--- a/runtime/src/configs/revive.rs
+++ b/runtime/src/configs/revive.rs
@@ -9,11 +9,21 @@ use sp_runtime::{
 	Perbill,
 };
 
-// Temporarily set to low values as a workaround for known gas estimation issues
+// Temporarily set to low deposit requirements for integration environment
+// as a workaround for known gas estimation issues
 parameter_types! {
-	pub const DepositPerItem: Balance = 1;//deposit(1,0);
-	pub const DepositPerByte: Balance = 1;//deposit(0,1);
-	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(0);//Perbill::from_percent(30);
+	#[cfg(feature = "develop")]
+	pub const DepositPerItem: Balance = 1;
+	#[cfg(not(feature = "develop"))]
+	pub const DepositPerItem: Balance = deposit(1,0);
+	#[cfg(feature = "develop")]
+	pub const DepositPerByte: Balance = 1;
+	#[cfg(not(feature = "develop"))]
+	pub const DepositPerByte: Balance = deposit(0,1);
+	#[cfg(feature = "develop")]
+	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(0);
+	#[cfg(not(feature = "develop"))]
+	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(30);
 }
 
 impl Config for Runtime {

--- a/runtime/src/configs/revive.rs
+++ b/runtime/src/configs/revive.rs
@@ -25,21 +25,6 @@ parameter_types! {
 	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(30);
 }
 
-parameter_types! {
-	#[cfg(feature = "develop")]
-	pub const DepositPerItem: Balance = 1;
-	#[cfg(not(feature = "develop"))]
-	pub const DepositPerItem: Balance = deposit(1,0);
-	#[cfg(feature = "develop")]
-	pub const DepositPerByte: Balance = 1;
-	#[cfg(not(feature = "develop"))]
-	pub const DepositPerByte: Balance = deposit(0,1);
-	#[cfg(feature = "develop")]
-	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(0);
-	#[cfg(not(feature = "develop"))]
-	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(30);
-}
-
 impl Config for Runtime {
 	type Time = Timestamp;
 	type Currency = Balances;

--- a/runtime/src/configs/revive.rs
+++ b/runtime/src/configs/revive.rs
@@ -11,6 +11,20 @@ use sp_runtime::{
 
 // Temporarily set to low deposit requirements for integration environment
 // as a workaround for known gas estimation issues
+#[cfg(feature = "develop")]
+parameter_types! {
+	pub const DepositPerItem: Balance = 1;
+	pub const DepositPerByte: Balance = 1;
+	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(0);
+}
+
+#[cfg(not(feature = "develop"))]
+parameter_types! {
+	pub const DepositPerItem: Balance = deposit(1,0);
+	pub const DepositPerByte: Balance = deposit(0,1);
+	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(30);
+}
+
 parameter_types! {
 	#[cfg(feature = "develop")]
 	pub const DepositPerItem: Balance = 1;

--- a/runtime/src/configs/revive.rs
+++ b/runtime/src/configs/revive.rs
@@ -9,10 +9,11 @@ use sp_runtime::{
 	Perbill,
 };
 
+// Temporarily set to low values as a workaround for known gas estimation issues
 parameter_types! {
-	pub const DepositPerItem: Balance = deposit(1, 0);
-	pub const DepositPerByte: Balance = deposit(0, 1);
-	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(30);
+	pub const DepositPerItem: Balance = 1;//deposit(1,0);
+	pub const DepositPerByte: Balance = 1;//deposit(0,1);
+	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(0);//Perbill::from_percent(30);
 }
 
 impl Config for Runtime {


### PR DESCRIPTION
These changes should resolve the issues with contract deployment testing that @aliTanveerAnalog is experiencing. We expect that the issues are due to bug(s) in gas estimation in the currently used version of pallet-revive.

## Follow Up(s)

 If we decide to merge this PR, we need to make a follow up issue so that these values are adjusted before mainnet launch so that we do not accidentally expose a DDOS attack vector.

Currently investigating a long-term fix that will be more secure than this short term patch. This research is driven by reading [differences with PolkaVM Gas Configuration](https://contracts.polkadot.io/differences_to_eth#scaling-of-gas-values) and the pallet-revive source code.