### PR TITLE
docker: add ca-certs to chronicle Docker image

### DIFF
--- a/config/docker/Dockerfile.chronicle-release
+++ b/config/docker/Dockerfile.chronicle-release
@@ -18,6 +18,10 @@ FROM ubuntu:22.04
 ARG PROFILE
 ARG VCS_REF
 
+RUN apt-get update && \
+	apt-get install -y ca-certificates && \
+	rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+
 LABEL description="Multistage Dockerfile for building Analog Chronicle" \
 	one.analog.image.type="builder" \
 	one.analog.image.authors="branimir@analog.one" \


### PR DESCRIPTION
## Description

Chronicle fails to connect to SSL secured endpoints so we need ca-certificates