### PR TITLE
runtime: switch to wasm32v1-none

### DIFF
--- a/.github/actions/build-contracts-tc-cli/action.yaml
+++ b/.github/actions/build-contracts-tc-cli/action.yaml
@@ -23,7 +23,7 @@ runs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
-        target: x86_64-unknown-linux-musl,wasm32-unknown-unknown
+        target: x86_64-unknown-linux-musl,wasm32v1-none
         components: rust-src
     - name: Install musl deps
       shell: bash

--- a/.github/workflows/merge-docker-slack-bot.yaml
+++ b/.github/workflows/merge-docker-slack-bot.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          target: x86_64-unknown-linux-musl,wasm32-unknown-unknown
+          target: x86_64-unknown-linux-musl,wasm32v1-none
           components: rust-src
       - name: Install musl deps
         run: sudo apt-get update && sudo apt-get install -y musl-tools

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.85.1"
 components = [ "rust-src", "rust-analyzer" ]
-targets = [ "x86_64-unknown-linux-musl", "wasm32-unknown-unknown" ]
+targets = [ "x86_64-unknown-linux-musl", "wasm32v1-none" ]


### PR DESCRIPTION
To speed up runtime build and ci times, we will want to switch to the `wasm32v1-none` toolchain, which will allow us to use the precompiled std library during build instead of recompiling it.