### PR TITLE
launch: support genesis builder for testing

### DIFF
--- a/pallets/launch/src/allocation.rs
+++ b/pallets/launch/src/allocation.rs
@@ -5,8 +5,8 @@ use crate::{
 
 use polkadot_sdk::*;
 
-use frame_support::traits::Currency;
-use frame_support::traits::VestingSchedule;
+use frame_support::assert_ok;
+use frame_support::traits::{Currency, VestingSchedule};
 use frame_system::pallet_prelude::BlockNumberFor;
 use sp_core::Get;
 use sp_runtime::traits::CheckedConversion;
@@ -254,5 +254,30 @@ impl AllocationTracker {
 			}
 		}
 		valid
+	}
+
+	/// Mint tokens in accordance with current tracker status into the associated virtual wallets.
+	/// Only to be used in testing or genesis builder as it panics on error.
+	pub fn mint<T: Config>(&self)
+	where
+		Balance: From<BalanceOf<T>>,
+		BalanceOf<T>: From<Balance>,
+	{
+		for i in 1..Allocation::num_of() {
+			let alloc = Allocation::from_index(i);
+
+			assert!(alloc.total() > self.per(alloc));
+
+			let remaining: Balance = alloc.total() - self.per(alloc);
+			let account = alloc.account_id::<T>();
+
+			let _ = CurrencyOf::<T>::deposit_creating(&account, remaining.into());
+
+			if let Some(vs) = alloc.schedule_rel::<T>(remaining.into()) {
+				assert_ok!(pallet_vesting::Pallet::<T>::add_vesting_schedule(
+					&account, vs.0, vs.1, vs.2
+				));
+			}
+		}
 	}
 }

--- a/pallets/launch/src/ledger.rs
+++ b/pallets/launch/src/ledger.rs
@@ -46,13 +46,8 @@ where
 
 				match version.cmp(&from) {
 					// Older migrations are just added up for verification
-					Ordering::Less => {
+					Ordering::Less | Ordering::Equal => {
 						tracker.add(*source, *amount);
-					},
-					// Current stage is used to verify issuance.
-					Ordering::Equal => {
-						tracker.add(*source, *amount);
-						ensure!(tracker.check::<T>(true), Error::<T>::TotalIssuanceExceeded);
 					},
 					// New migrations are added to launch plan
 					Ordering::Greater => {
@@ -74,6 +69,18 @@ where
 		}
 
 		Ok(LaunchLedger(tracker, stages, Default::default()))
+	}
+
+	/// Verify the current on-chain state based on previous stages in ledger
+	pub fn verify(self) -> Result<Self, Error<T>> {
+		ensure!(self.0.check::<T>(true), Error::<T>::TotalIssuanceExceeded);
+		Ok(self)
+	}
+
+	/// Build currently expected state of virtual wallet before the execution of any launch stage.
+	/// To be used in testing to more easily simulate current on-chain state, panics on error.
+	pub fn to_genesis(&self) {
+		self.0.mint::<T>();
 	}
 
 	/// Run a compiled and verified LaunchLedger as far as possible and return

--- a/pallets/launch/src/lib.rs
+++ b/pallets/launch/src/lib.rs
@@ -48,9 +48,11 @@ pub type RawVestingSchedule = (Balance, Balance, BlockNumber);
 pub mod pallet {
 	// Import various useful types required by all FRAME pallets.
 	use super::*;
+	use core::marker::PhantomData;
 	use frame_support::pallet_prelude::*;
 	use frame_support::traits::{
-		Currency, ExistenceRequirement, LockableCurrency, StorageVersion, WithdrawReasons,
+		BuildGenesisConfig, Currency, ExistenceRequirement, LockableCurrency, StorageVersion,
+		WithdrawReasons,
 	};
 	use frame_support::PalletId;
 	use frame_system::pallet_prelude::*;
@@ -173,6 +175,38 @@ pub mod pallet {
 	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		/// Stage to which initialize storage, defaults to latest stage.
+		stage: u16,
+		phantom: PhantomData<T>,
+	}
+
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			Self {
+				stage: LAUNCH_VERSION,
+				phantom: PhantomData,
+			}
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> BuildGenesisConfig for GenesisConfig<T>
+	where
+		T::AccountId: From<AccountId>,
+		Balance: From<BalanceOf<T>> + From<AirdropBalanceOf<T>>,
+		BalanceOf<T>: From<Balance>,
+	{
+		fn build(&self) {
+			StorageVersion::new(self.stage).put::<Pallet<T>>();
+			let plan =
+				LaunchLedger::<T>::compile(LAUNCH_LEDGER).expect("Failed to parse launch ledger");
+			plan.to_genesis();
+			assert!(plan.verify().is_ok(), "Failed to generate valid genesis");
+		}
+	}
+
 	#[pallet::config]
 	pub trait Config:
 		polkadot_sdk::frame_system::Config + pallet_vesting::Config + pallet_airdrop::Config
@@ -256,7 +290,7 @@ pub mod pallet {
 		BalanceOf<T>: From<Balance>,
 	{
 		fn on_runtime_upgrade() -> frame_support::weights::Weight {
-			match LaunchLedger::compile(LAUNCH_LEDGER) {
+			match LaunchLedger::compile(LAUNCH_LEDGER).and_then(|p| p.verify()) {
 				Ok(plan) => return plan.run(),
 				Err(error) => {
 					log::error!(


### PR DESCRIPTION
This fixes #1589, please read for details. Defaults to the latest stage but can be configured via the genesis config to test specific updates.