### PR TITLE
governance: add develop-only balances admin

### DIFF
--- a/pallets/governance/Cargo.toml
+++ b/pallets/governance/Cargo.toml
@@ -26,6 +26,7 @@ polkadot-sdk = { workspace = true, features = [ "frame-election-provider-support
 
 [features]
 default = ["std"]
+develop = []
 std = [
 	"scale-codec/std",
 	"scale-info/std",
@@ -41,4 +42,3 @@ runtime-benchmarks = [
 try-runtime = [
 	"polkadot-sdk/try-runtime",
 ]
-broken = []

--- a/pallets/governance/src/lib.rs
+++ b/pallets/governance/src/lib.rs
@@ -32,8 +32,14 @@ pub mod pallet {
 	// Additional custom imports
 	use frame_system::{RawOrigin, WeightInfo as SystemWeights};
 
+	#[cfg(feature = "develop")]
+	use pallet_balances::WeightInfo as BalancesWeights;
+
 	use pallet_staking::{ConfigOp, WeightInfo as StakingWeights};
 	use sp_runtime::{Perbill, Percent};
+
+	#[cfg(feature = "develop")]
+	use sp_runtime::traits::StaticLookup;
 
 	// Useful coupling shorthands
 	type CurrencyBalanceOf<T> = <T as pallet_staking::Config>::CurrencyBalance;
@@ -47,8 +53,11 @@ pub mod pallet {
 	{
 		/// Allowed origin for system calls
 		type SystemAdmin: EnsureOrigin<Self::RuntimeOrigin>;
-		// Allowed origin for staking calls
+		/// Allowed origin for staking calls
 		type StakingAdmin: EnsureOrigin<Self::RuntimeOrigin>;
+		#[cfg(feature = "develop")]
+		/// Allowed origin for balances calls
+		type BalancesAdmin: EnsureOrigin<Self::RuntimeOrigin>;
 	}
 
 	#[pallet::call]
@@ -106,6 +115,21 @@ pub mod pallet {
 				min_commission,
 				max_staked_rewards,
 			)
+		}
+
+		#[cfg(feature = "develop")]
+		#[pallet::call_index(4)]
+		#[pallet::weight(
+			<T as pallet_balances::Config>::WeightInfo::force_set_balance_creating()
+				.max(<T as pallet_balances::Config>::WeightInfo::force_set_balance_killing())
+		)]
+		pub fn force_set_balance(
+			origin: OriginFor<T>,
+			who: <T::Lookup as StaticLookup>::Source,
+			#[pallet::compact] new_free: T::Balance,
+		) -> DispatchResult {
+			T::BalancesAdmin::ensure_origin(origin)?;
+			pallet_balances::Pallet::<T>::force_set_balance(RawOrigin::Root.into(), who, new_free)
 		}
 	}
 }

--- a/pallets/governance/src/mock.rs
+++ b/pallets/governance/src/mock.rs
@@ -25,7 +25,8 @@ construct_runtime!(
 ord_parameter_types! {
 	pub const SystemAdmin: AccountId = 1;
 	pub const StakingAdmin: AccountId = 2;
-	pub const Other: AccountId = 3;
+	pub const BalancesAdmin: AccountId = 3;
+	pub const Other: AccountId = 4;
 }
 
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
@@ -113,6 +114,8 @@ impl pallet_staking::Config for Test {
 impl pallet_governance::Config for Test {
 	type SystemAdmin = EnsureSignedBy<SystemAdmin, AccountId>;
 	type StakingAdmin = EnsureSignedBy<StakingAdmin, AccountId>;
+	#[cfg(feature = "develop")]
+	type BalancesAdmin = EnsureSignedBy<BalancesAdmin, AccountId>;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -113,6 +113,7 @@ testnet = [ "time-primitives/testnet" ]
 develop = [
   "genesis-builder",
   "time-primitives/develop",
+  "pallet-governance/develop",
 ]
 with-tracing = [ "polkadot-sdk/with-tracing" ]
 std = [

--- a/runtime/src/configs/governance.rs
+++ b/runtime/src/configs/governance.rs
@@ -104,6 +104,9 @@ parameter_types! {
 impl pallet_governance::Config for Runtime {
 	/// Default admin origin for system related governance
 	type SystemAdmin = DefaultAdminOrigin;
-	// Default admin origin for staking related governance
+	/// Default admin origin for staking related governance
 	type StakingAdmin = DefaultAdminOrigin;
+	#[cfg(feature = "develop")]
+	/// Default admin origin for balances related governance
+	type BalancesAdmin = DefaultAdminOrigin;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -299,11 +299,12 @@ pub const BABE_GENESIS_EPOCH_CONFIG: sp_consensus_babe::BabeEpochConfiguration =
 		allowed_slots: sp_consensus_babe::AllowedSlots::PrimaryAndSecondaryVRFSlots,
 	};
 
-/// TODO: Clean this up and move to tokenomics
-pub const STORAGE_BYTE_FEE: Balance = 300 * MILLIANLOG; // Change based on benchmarking
+/// Shared per-byte storage fee
+pub const STORAGE_BYTE_FEE: Balance = MILLIANLOG;
 
+/// Shared fee structure for items put in storage
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
-	items as Balance * 750 * MILLIANLOG + (bytes as Balance) * STORAGE_BYTE_FEE
+	items as Balance * 10 * ANLOG + (bytes as Balance) * STORAGE_BYTE_FEE
 }
 
 parameter_types! {


### PR DESCRIPTION
This adds an additional admin to the governance pallet that allows the manipulation of account balances to be used to simplify testing.

It also updates the deposit fee structure closer to what is deployed on other chains to cheapen revive fees.