### PR TITLE
polkadot-sdk: v1.18.3-anlog0 -> v1.18.5-anlog0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,7 +1661,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "asset-test-utils"
 version = "23.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "assets-common"
 version = "0.21.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2276,7 +2276,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "hash-db",
  "log",
@@ -2625,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.20.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.20.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -2658,7 +2658,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.20.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -2692,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.20.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.20.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -2753,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.6.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2782,7 +2782,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.13.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2801,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-test-utils"
 version = "0.22.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -2843,7 +2843,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.21.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.22.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.22.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.22.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.22.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.19.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.22.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -4044,7 +4044,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.22.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4079,7 +4079,7 @@ dependencies = [
  "cumulus-test-relay-sproof-builder",
  "parity-scale-codec",
  "sc-client-api",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.22.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4116,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.23.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -4170,7 +4170,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -4187,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "21.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -4280,7 +4280,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.19.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -4295,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -4320,7 +4320,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -4344,7 +4344,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.18.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.18.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4374,7 +4374,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.12.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -4384,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "11.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -4401,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.19.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -4411,7 +4411,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -4428,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.23.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4452,7 +4452,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.22.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4470,8 +4470,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.23.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "0.23.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.22.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4545,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.19.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -5723,7 +5723,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -5755,8 +5755,8 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "40.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -5779,8 +5779,8 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "47.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "47.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -5839,8 +5839,8 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-pallet-pov"
-version = "30.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "30.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5881,8 +5881,8 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-solution-type"
-version = "16.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "16.1.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -5892,8 +5892,8 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-support"
-version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "40.1.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5908,8 +5908,8 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "40.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5962,7 +5962,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.8.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -5978,7 +5978,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -6018,8 +6018,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "33.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "33.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -6032,14 +6032,14 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "syn 2.0.101",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.3.0",
@@ -6051,7 +6051,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6061,7 +6061,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cfg-if",
  "docify",
@@ -6080,7 +6080,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6094,7 +6094,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -6104,7 +6104,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.46.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6399,7 +6399,7 @@ dependencies = [
 [[package]]
 name = "generate-bags"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "chrono",
  "frame-election-provider-support",
@@ -7098,6 +7098,16 @@ name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"
@@ -9204,7 +9214,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "44.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "log",
@@ -9223,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10015,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "39.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "frame-benchmarking",
@@ -10027,7 +10037,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-io",
  "sp-runtime",
 ]
@@ -10035,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10053,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.8.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10071,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10086,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "19.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10100,7 +10110,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rewards"
 version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10118,7 +10128,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10135,7 +10145,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "42.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10151,7 +10161,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "log",
  "pallet-assets",
@@ -10163,7 +10173,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-holder"
 version = "0.2.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10178,7 +10188,7 @@ dependencies = [
 [[package]]
 name = "pallet-atomic-swap"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10188,7 +10198,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10204,7 +10214,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10219,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10232,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10255,7 +10265,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "39.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "aquamarine",
  "docify",
@@ -10276,7 +10286,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "41.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10291,8 +10301,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy"
-version = "41.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "41.1.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10311,7 +10321,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "41.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -10336,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10353,7 +10363,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -10372,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.20.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -10391,7 +10401,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -10411,7 +10421,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -10434,7 +10444,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.19.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10452,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10470,7 +10480,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "21.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10489,7 +10499,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10506,7 +10516,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.18.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10520,7 +10530,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10551,7 +10561,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10582,7 +10592,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.3"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10592,7 +10602,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "14.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -10603,7 +10613,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10619,7 +10629,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "24.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10637,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "7.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10652,7 +10662,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10669,7 +10679,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10693,8 +10703,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "39.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "39.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10716,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10746,7 +10756,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "41.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10764,7 +10774,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10782,7 +10792,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -10810,7 +10820,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10832,7 +10842,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10848,7 +10858,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "39.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10867,7 +10877,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10882,7 +10892,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10906,7 +10916,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10932,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10948,7 +10958,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "43.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10967,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10985,7 +10995,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "10.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11004,7 +11014,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.16.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11018,7 +11028,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11030,7 +11040,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11052,7 +11062,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "23.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11068,7 +11078,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "34.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -11085,7 +11095,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11094,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11104,7 +11114,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11115,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "38.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11133,7 +11143,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11153,7 +11163,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -11163,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11178,7 +11188,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11201,7 +11211,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.18.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-support",
@@ -11217,7 +11227,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.11.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11234,7 +11244,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11250,7 +11260,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11260,7 +11270,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11278,7 +11288,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11292,7 +11302,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -11310,7 +11320,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11325,8 +11335,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-revive"
-version = "0.5.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "0.6.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "alloy-core 0.8.25",
  "derive_more 0.99.20",
@@ -11337,6 +11347,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex-literal 0.4.1",
+ "humantime-serde",
  "impl-trait-for-tuples",
  "log",
  "num-bigint",
@@ -11373,7 +11384,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.3.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -11386,8 +11397,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-revive-mock-network"
-version = "0.4.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "0.5.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11416,7 +11427,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.3.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11426,7 +11437,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.4.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
@@ -11438,7 +11449,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "37.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11453,7 +11464,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11467,7 +11478,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "21.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11485,7 +11496,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "25.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "log",
  "pallet-ranked-collective",
@@ -11496,8 +11507,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-scheduler"
-version = "41.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "41.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11514,7 +11525,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11526,8 +11537,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "40.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11548,7 +11559,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11579,7 +11590,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "15.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11591,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11607,8 +11618,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "40.1.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11630,7 +11641,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -11641,7 +11652,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -11650,7 +11661,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11660,7 +11671,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "44.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11676,7 +11687,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11693,7 +11704,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11735,7 +11746,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11754,7 +11765,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11772,7 +11783,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11788,7 +11799,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "43.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -11804,7 +11815,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -11816,7 +11827,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "frame-benchmarking",
@@ -11836,7 +11847,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11855,7 +11866,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "21.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -11869,7 +11880,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11883,7 +11894,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "40.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11898,7 +11909,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.3.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11914,7 +11925,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11928,7 +11939,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11937,8 +11948,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "19.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "19.1.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -11961,7 +11972,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "20.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11977,8 +11988,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub"
-version = "0.16.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "0.16.3"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -12000,7 +12011,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.18.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -12030,7 +12041,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "21.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -12059,7 +12070,7 @@ dependencies = [
 [[package]]
 name = "parachains-runtimes-test-utils"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -12520,7 +12531,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12538,7 +12549,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12553,7 +12564,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "fatality",
  "futures",
@@ -12576,7 +12587,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "fatality",
@@ -12609,7 +12620,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "23.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -12633,7 +12644,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12656,7 +12667,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "17.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12667,7 +12678,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "22.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "fatality",
  "futures",
@@ -12689,7 +12700,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "19.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -12703,7 +12714,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12716,7 +12727,7 @@ dependencies = [
  "sc-network",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-keystore",
  "tracing-gum",
 ]
@@ -12724,7 +12735,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -12747,7 +12758,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -12765,7 +12776,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -12797,7 +12808,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.5.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -12821,7 +12832,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bitvec",
  "futures",
@@ -12840,7 +12851,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12861,7 +12872,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -12876,7 +12887,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -12898,7 +12909,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -12912,7 +12923,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12927,8 +12938,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "22.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "fatality",
  "futures",
@@ -12946,7 +12957,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -12963,7 +12974,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "21.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "fatality",
  "futures",
@@ -12977,7 +12988,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12994,7 +13005,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -13022,7 +13033,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -13035,7 +13046,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "19.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cpu-time",
  "futures",
@@ -13050,7 +13061,7 @@ dependencies = [
  "sc-executor-wasmtime",
  "seccompiler",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-externalities",
  "sp-io",
  "sp-tracing",
@@ -13061,7 +13072,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -13076,7 +13087,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bs58",
  "futures",
@@ -13093,7 +13104,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -13118,7 +13129,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "19.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -13142,7 +13153,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -13151,7 +13162,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -13179,7 +13190,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "fatality",
  "futures",
@@ -13210,7 +13221,7 @@ dependencies = [
 [[package]]
 name = "polkadot-omni-node-lib"
 version = "0.5.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "clap",
@@ -13269,7 +13280,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-aura",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-keystore",
@@ -13291,7 +13302,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -13311,7 +13322,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "16.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.20",
@@ -13327,7 +13338,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "18.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bitvec",
  "hex-literal 0.4.1",
@@ -13355,7 +13366,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "23.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -13388,7 +13399,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "19.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -13438,7 +13449,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "20.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -13450,7 +13461,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "19.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -13506,7 +13517,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk"
 version = "2503.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -13717,7 +13728,7 @@ dependencies = [
  "sp-core",
  "sp-core-hashing",
  "sp-crypto-ec-utils",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-genesis-builder",
@@ -13762,7 +13773,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.9.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -13797,7 +13808,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "23.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -13904,8 +13915,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "22.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -13928,7 +13939,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "19.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -15202,7 +15213,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "22.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -15300,7 +15311,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "20.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -15756,7 +15767,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "31.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "log",
  "sp-core",
@@ -15767,7 +15778,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.49.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -15795,7 +15806,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.49.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "log",
@@ -15816,7 +15827,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.44.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -15831,7 +15842,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "42.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "clap",
@@ -15847,7 +15858,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -15858,7 +15869,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -15869,7 +15880,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.51.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -15911,7 +15922,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "fnv",
  "futures",
@@ -15937,7 +15948,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.46.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -15963,7 +15974,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.48.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -15986,7 +15997,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.49.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -16015,7 +16026,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.49.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -16040,7 +16051,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -16051,7 +16062,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.49.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -16073,7 +16084,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -16107,7 +16118,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "28.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -16127,7 +16138,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.48.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -16140,7 +16151,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.34.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -16174,7 +16185,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -16184,7 +16195,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.34.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -16204,7 +16215,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.50.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -16239,7 +16250,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.48.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -16262,7 +16273,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.42.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -16285,7 +16296,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.38.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "polkavm 0.18.0",
  "sc-allocator",
@@ -16298,7 +16309,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.35.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "log",
  "polkavm 0.18.0",
@@ -16309,7 +16320,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.38.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "anyhow",
  "log",
@@ -16325,7 +16336,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.48.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "console",
  "futures",
@@ -16341,7 +16352,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "35.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -16355,7 +16366,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.19.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -16383,7 +16394,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.49.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -16433,7 +16444,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.48.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -16443,7 +16454,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.49.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "ahash",
  "futures",
@@ -16462,7 +16473,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.48.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -16483,7 +16494,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.48.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -16518,7 +16529,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.48.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "futures",
@@ -16537,7 +16548,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.15.3"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bs58",
  "bytes",
@@ -16556,7 +16567,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "44.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bytes",
  "fnv",
@@ -16590,7 +16601,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -16599,7 +16610,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "44.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -16631,7 +16642,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.48.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -16651,7 +16662,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "21.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -16675,7 +16686,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.49.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "futures",
@@ -16707,13 +16718,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.2.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -16722,7 +16733,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.50.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "directories",
@@ -16786,7 +16797,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.38.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16797,7 +16808,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.24.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "clap",
  "fs4",
@@ -16810,7 +16821,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.49.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -16829,7 +16840,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "42.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -16842,14 +16853,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "28.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "chrono",
  "futures",
@@ -16868,7 +16879,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "chrono",
  "console",
@@ -16896,7 +16907,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -16907,7 +16918,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -16925,7 +16936,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -16939,7 +16950,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -16956,7 +16967,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "18.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -17902,7 +17913,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "17.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -18167,8 +18178,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-core"
-version = "0.13.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "0.13.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bp-relayers",
  "ethabi-decode",
@@ -18244,7 +18255,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "36.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "hash-db",
@@ -18265,8 +18276,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "22.0.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -18280,7 +18291,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "40.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18292,7 +18303,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -18306,7 +18317,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18318,7 +18329,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -18328,7 +18339,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -18347,7 +18358,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.42.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "futures",
@@ -18361,7 +18372,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.42.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18377,7 +18388,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.42.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18395,7 +18406,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "24.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18403,7 +18414,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -18415,7 +18426,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "23.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -18432,7 +18443,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-pow"
 version = "0.42.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -18443,7 +18454,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.42.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18454,7 +18465,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "36.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -18484,7 +18495,7 @@ dependencies = [
  "secp256k1 0.28.2",
  "secrecy 0.8.0",
  "serde",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -18501,15 +18512,15 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "16.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
 ]
 
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.15.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -18543,7 +18554,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -18556,17 +18567,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "syn 2.0.101",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -18575,7 +18586,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -18585,7 +18596,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -18595,7 +18606,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.17.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18607,7 +18618,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -18620,7 +18631,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "40.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bytes",
  "docify",
@@ -18632,7 +18643,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -18646,7 +18657,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "41.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -18656,7 +18667,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.42.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -18667,7 +18678,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -18676,7 +18687,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.10.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-metadata 20.0.0",
  "parity-scale-codec",
@@ -18686,7 +18697,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18697,7 +18708,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "36.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -18713,8 +18724,8 @@ dependencies = [
 
 [[package]]
 name = "sp-npos-elections"
-version = "36.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "36.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18727,7 +18738,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -18737,7 +18748,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "backtrace",
  "regex",
@@ -18746,7 +18757,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "34.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -18756,7 +18767,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "41.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -18785,7 +18796,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "29.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -18804,7 +18815,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "Inflector",
  "expander",
@@ -18817,7 +18828,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "38.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18831,7 +18842,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "38.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -18844,7 +18855,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.45.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "hash-db",
  "log",
@@ -18864,7 +18875,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "20.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -18877,7 +18888,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -18888,12 +18899,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18905,7 +18916,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18917,7 +18928,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -18928,7 +18939,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "36.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -18937,7 +18948,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "36.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18951,7 +18962,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "39.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "ahash",
  "hash-db",
@@ -18973,7 +18984,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "39.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18990,7 +19001,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -19002,7 +19013,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -19014,7 +19025,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -19082,7 +19093,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-chain-spec-builder"
 version = "10.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "clap",
  "docify",
@@ -19095,7 +19106,7 @@ dependencies = [
 [[package]]
 name = "staging-node-inspect"
 version = "0.27.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -19113,7 +19124,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.20.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -19125,8 +19136,8 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "16.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "16.2.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -19146,8 +19157,8 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "20.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "20.1.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "environmental",
  "frame-support",
@@ -19170,8 +19181,8 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "19.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "19.1.2"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -19381,7 +19392,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -19406,12 +19417,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "43.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -19431,7 +19442,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.2"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -19445,7 +19456,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "42.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -19462,7 +19473,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "26.0.1"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -20167,7 +20178,7 @@ dependencies = [
 [[package]]
 name = "testnet-parachains-constants"
 version = "13.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -20788,7 +20799,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "19.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -20799,7 +20810,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "expander",
  "proc-macro-crate 3.3.0",
@@ -21852,8 +21863,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "22.1.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "22.3.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -21962,7 +21973,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "20.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -22621,7 +22632,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -22631,8 +22642,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.7.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "0.7.1"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -22645,8 +22656,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-simulator"
-version = "20.0.0"
-source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.3-anlog0#0c51511a272b70df1d3539352fa131b7e6a68db4"
+version = "20.1.0"
+source = "git+https://github.com/Analog-Labs/polkadot-sdk?tag=v1.18.5-anlog0#b5f4a94ad034a82abc5ece1682cd49dd8e4c52ed"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,10 +77,10 @@ scale-decode = { version = "0.16.0", default-features = false, features = [ "der
 scale-info = { version = "2.11.6", default-features = false, features = [ "derive" ] }
 
 # main substrate sdk
-polkadot-sdk = { git = "https://github.com/Analog-Labs/polkadot-sdk", tag = "v1.18.3-anlog0", default-features = false }
+polkadot-sdk = { git = "https://github.com/Analog-Labs/polkadot-sdk", tag = "v1.18.5-anlog0", default-features = false }
 
 # specialized wasm builder
-substrate-wasm-builder = { git = "https://github.com/Analog-Labs/polkadot-sdk", tag = "v1.18.3-anlog0", features = [ "metadata-hash" ] }
+substrate-wasm-builder = { git = "https://github.com/Analog-Labs/polkadot-sdk", tag = "v1.18.5-anlog0", features = [ "metadata-hash" ] }
 
 # metadata based chain interaction
 subxt = { git = "https://github.com/Analog-Labs/subxt", tag = "v0.41.0-anlog0" }

--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,9 @@
         buildInputs = [
           tpkgs.zlib.static
         ];
+
+        # Hardening breaks tikv-jemallocator
+        NIX_HARDENING_ENABLE = "";
       };
 
       # Create developer shell for combination of build package set and target abi

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -514,20 +514,20 @@ sp_api::impl_runtime_apis! {
 
 		fn trace_block(
 			block: Block,
-			config: pallet_revive::evm::TracerConfig
-		) -> Vec<(u32, pallet_revive::evm::CallTrace)> {
+			tracer_type: pallet_revive::evm::TracerType
+		) -> Vec<(u32, pallet_revive::evm::Trace)> {
 			use pallet_revive::tracing::trace;
-			let mut tracer = config.build(Revive::evm_gas_from_weight);
+			let mut tracer = Revive::evm_tracer(tracer_type);
 			let mut traces = vec![];
 			let (header, extrinsics) = block.deconstruct();
 
 			Executive::initialize_block(&header);
 			for (index, ext) in extrinsics.into_iter().enumerate() {
-				trace(&mut tracer, || {
+				trace(tracer.as_tracing(), || {
 					let _ = Executive::apply_extrinsic(ext);
 				});
 
-				if let Some(tx_trace) = tracer.collect_traces().pop() {
+				if let Some(tx_trace) = tracer.collect_trace() {
 					traces.push((index as u32, tx_trace));
 				}
 			}
@@ -538,16 +538,16 @@ sp_api::impl_runtime_apis! {
 		fn trace_tx(
 			block: Block,
 			tx_index: u32,
-			config: pallet_revive::evm::TracerConfig
-		) -> Option<pallet_revive::evm::CallTrace> {
+			tracer_type: pallet_revive::evm::TracerType
+		) -> Option<pallet_revive::evm::Trace> {
 			use pallet_revive::tracing::trace;
-			let mut tracer = config.build(Revive::evm_gas_from_weight);
+			let mut tracer = Revive::evm_tracer(tracer_type);
 			let (header, extrinsics) = block.deconstruct();
 
 			Executive::initialize_block(&header);
 			for (index, ext) in extrinsics.into_iter().enumerate() {
 				if index as u32 == tx_index {
-					trace(&mut tracer, || {
+					trace(tracer.as_tracing(), || {
 					let _ = Executive::apply_extrinsic(ext);
 					});
 					break;
@@ -556,24 +556,24 @@ sp_api::impl_runtime_apis! {
 				}
 			}
 
-			tracer.collect_traces().pop()
+			tracer.collect_trace()
 		}
 
 		fn trace_call(
 			tx: pallet_revive::evm::GenericTransaction,
-			config: pallet_revive::evm::TracerConfig)
-			-> Result<pallet_revive::evm::CallTrace, pallet_revive::EthTransactError>
+			trace_type: pallet_revive::evm::TracerType)
+			-> Result<pallet_revive::evm::Trace, pallet_revive::EthTransactError>
 		{
 			use pallet_revive::tracing::trace;
-			let mut tracer = config.build(Revive::evm_gas_from_weight);
-			let result = trace(&mut tracer, || Self::eth_transact(tx));
+			let mut tracer = Revive::evm_tracer(trace_type);
+			let result = trace(tracer.as_tracing(), || Self::eth_transact(tx));
 
-			if let Some(trace) = tracer.collect_traces().pop() {
+			if let Some(trace) = tracer.collect_trace() {
 				Ok(trace)
 			} else if let Err(err) = result {
 				Err(err)
 			} else {
-				Ok(Default::default())
+				Ok(tracer.empty_trace())
 			}
 		}
 	}


### PR DESCRIPTION
Updates to latest Polkdot SDK,, most notably has some fixes for revive tracing and scheduler pallet.