### PR TITLE
Fix Typos in Comments and Log Messages

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -258,7 +258,7 @@ pub type Executive = frame_executive::Executive<
 	Migrations,
 >;
 
-// Useful types when handeling currency
+// Useful types when handling currency
 pub type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;
 pub type PositiveImbalance = <Balances as Currency<AccountId>>::PositiveImbalance;
 

--- a/tc-cli/src/lib.rs
+++ b/tc-cli/src/lib.rs
@@ -283,7 +283,7 @@ impl Tc {
 		self.println(
 			None,
 			format!(
-				"transfering {} to {}",
+				"transferring {} to {}",
 				self.format_balance(network, balance)?,
 				self.format_address(network, address)?,
 			),


### PR DESCRIPTION



Description:  
This pull request corrects minor spelling mistakes in the codebase. Specifically, it changes "handeling" to "handling" in a comment within runtime/src/lib.rs, and "transfering" to "transferring" in a log message within tc-cli/src/lib.rs. These changes improve code readability and maintain consistency in documentation and output messages. No functional code was altered.