### PR TITLE
launch: add investor snapshot 16

### DIFF
--- a/pallets/launch/src/data/mod.rs
+++ b/pallets/launch/src/data/mod.rs
@@ -2,3 +2,7 @@
 pub mod v78;
 pub mod v79;
 pub mod v80;
+pub mod v81;
+pub mod v82;
+pub mod v83;
+pub mod v84;

--- a/pallets/launch/src/data/v81.rs
+++ b/pallets/launch/src/data/v81.rs
@@ -1,0 +1,6 @@
+use crate::deposits::RawDepositStage;
+
+use time_primitives::ANLOG;
+
+pub const SEED_SNAPSHOT_16: RawDepositStage =
+	&[("an6oGBdayY68qnb7gk8Rd9vRGca3DEY1NP4JC5YkrVRkWHzSC", 90_579_710 * ANLOG)];

--- a/pallets/launch/src/data/v82.rs
+++ b/pallets/launch/src/data/v82.rs
@@ -1,0 +1,6 @@
+use crate::deposits::RawDepositStage;
+
+use time_primitives::ANLOG;
+
+pub const PRIVATE1_SNAPSHOT_16: RawDepositStage =
+	&[("an6oGBdayY68qnb7gk8Rd9vRGca3DEY1NP4JC5YkrVRkWHzSC", 181_159_420 * ANLOG)];

--- a/pallets/launch/src/data/v83.rs
+++ b/pallets/launch/src/data/v83.rs
@@ -1,0 +1,13 @@
+use crate::deposits::RawVestedDepositStage;
+
+use time_primitives::MILLIANLOG;
+
+pub const OPPORTUNITY4_SNAPSHOT_16: RawVestedDepositStage = &[(
+	"an5s9VGeqXaDZbx4D4vxtiXT6LdxYTSPBZUww6AeCu1jvQdH7",
+	4_076_087_400 * MILLIANLOG,
+	// 10% TGE was already sent manually. Remaining = 90% = 4,076,087.4 ANLOG
+	// Vesting: 12 months linear, start = Opportunity4 TGE block (2,008,470)
+	// total_vesting_blocks = 12 * 439,200 = 5,270,400
+	// per_block = 4,076,087.4 ANLOG / 5,270,400 = 0.773392 ANLOG
+	Some((4_076_087_400 * MILLIANLOG, 773 * MILLIANLOG, 2_008_470)),
+)];

--- a/pallets/launch/src/data/v84.rs
+++ b/pallets/launch/src/data/v84.rs
@@ -1,0 +1,6 @@
+use crate::deposits::RawDepositStage;
+
+use time_primitives::ANLOG;
+
+pub const STRATEGIC_SNAPSHOT_16: RawDepositStage =
+	&[("anAgjbcKW3xShfg1GNm2igFrnWCZfLkiL8YwSgxvLoxdWGRVW", 1_508_152 * ANLOG)];

--- a/pallets/launch/src/lib.rs
+++ b/pallets/launch/src/lib.rs
@@ -54,7 +54,7 @@ pub mod pallet {
 	use sp_std::{vec, vec::Vec};
 
 	/// Updating this number will automatically execute the next launch stages on update
-	pub const LAUNCH_VERSION: u16 = 80;
+	pub const LAUNCH_VERSION: u16 = 84;
 	/// Wrapped version to support substrate interface as well
 	pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(LAUNCH_VERSION);
 
@@ -204,6 +204,31 @@ pub mod pallet {
 			Allocation::Private1,
 			2_368_044 * ANLOG,
 			Stage::DepositAsVestedWithOverride(data::v80::PRIVATE1_SNAPSHOT_15),
+		),
+		// Investor snapshot 16
+		(
+			81,
+			Allocation::Seed,
+			90_579_710 * ANLOG,
+			Stage::DepositAsVested(data::v81::SEED_SNAPSHOT_16),
+		),
+		(
+			82,
+			Allocation::Private1,
+			181_159_420 * ANLOG,
+			Stage::DepositAsVested(data::v82::PRIVATE1_SNAPSHOT_16),
+		),
+		(
+			83,
+			Allocation::Opportunity4,
+			4_076_087_400 * MILLIANLOG, // 90% remaining (10% TGE already sent)
+			Stage::DepositFromUnlocked(data::v83::OPPORTUNITY4_SNAPSHOT_16),
+		),
+		(
+			84,
+			Allocation::Strategic,
+			1_508_152 * ANLOG,
+			Stage::DepositAsVested(data::v84::STRATEGIC_SNAPSHOT_16),
 		),
 	];
 


### PR DESCRIPTION
- Bump LAUNCH_VERSION from 80 to 84
- Add 4 new stages for investor snapshot 16:
  - v81: Seed (90,579,710 ANLOG) - DepositAsVested
  - v82: Private1 (181,159,420 ANLOG) - DepositAsVested
  - v83: Opportunity4 (4,076,087.4 ANLOG, 90% remaining, TGE already sent) - DepositFromUnlocked with 12-month linear vesting from block 2,008,470
  - v84: Strategic (1,508,152 ANLOG) - DepositAsVested

## Description

Adds investor snapshot 16 batch to the runtime upgrade launch ledger.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Tests

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:

## Code review prechecks:

- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Inline comments have been added for each method
- [ ] I have made corresponding changes to the documentation
- [ ] Code changes introduces no new problems or warnings
- [ ] Test cases have been added 
- [ ] Dependent changes have been merged and published in downstream modules